### PR TITLE
add /portfolio api and add new table and improve code and model

### DIFF
--- a/backend/app/common/types/avatar_type.go
+++ b/backend/app/common/types/avatar_type.go
@@ -1,0 +1,15 @@
+package commonType
+
+type AvatarType int
+
+const (
+	DefaultAvatar AvatarType = iota + 1
+)
+
+func (t AvatarType) String() string {
+	return [...]string{"Default"}[t]
+}
+
+func (t AvatarType) IsValid() bool {
+	return t >= DefaultAvatar && t <= DefaultAvatar
+}

--- a/backend/app/migrations/migrations.go
+++ b/backend/app/migrations/migrations.go
@@ -52,7 +52,7 @@ func main() {
 
 	// migration log database
 	err = con.LogDB.AutoMigrate(
-		&models.Log{},
+		&models.TransactionAudit{},
 	)
 	if err != nil {
 		log.Error("app-migrate-config-error", "Failed to migrate the log database")

--- a/backend/app/models/account_model.go
+++ b/backend/app/models/account_model.go
@@ -9,6 +9,6 @@ type Account struct {
 	Name                 string                 `gorm:"column:name;type:varchar(30);not null"`
 	Type                 string                 `gorm:"column:type;type:enum('bank', 'credit', 'wallet', 'investment');not null"`
 	Balance              float64                `gorm:"column:balance;type:decimal(15,2);default:0.00"`
-	Transaction          []Transaction          `gorm:"foreignKey:account_id"`
-	RecurringTransaction []RecurringTransaction `gorm:"foreignKey:account_id"`
+	Transaction          []Transaction          `gorm:"foreignKey:AccountId;constraint:OnDelete:CASCADE;"`
+	RecurringTransaction []RecurringTransaction `gorm:"foreignKey:AccountId;constraint:OnDelete:CASCADE;"`
 }

--- a/backend/app/models/admin_model.go
+++ b/backend/app/models/admin_model.go
@@ -1,0 +1,14 @@
+package models
+
+import "gorm.io/gorm"
+
+type Admin struct {
+	gorm.Model
+	Name     string     `gorm:"column:name;type:varchar(30);not null"`
+	Email    string     `gorm:"column:email;type:varchar(100);unique;not null"`
+	Username string     `gorm:"column:username;type:varchar(20);unique;not null"`
+	Password string     `gorm:"column:password;type:varchar(100);not null"`
+	AvatarId uint       `gorm:"column:avatar_id"`
+	Avatar   []Avatar   `gorm:"foreignKey:AdminId;constraint:OnDelete:CASCADE;"`
+	Category []Category `gorm:"foreignKey:AdminId;constraint:OnDelete:CASCADE;"`
+}

--- a/backend/app/models/avatar_model.go
+++ b/backend/app/models/avatar_model.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"gorm.io/gorm"
+)
+
+type Avatar struct {
+	gorm.Model
+	Name    string                `gorm:"column:name;not null"`
+	Url     string                `gorm:"column:url;type:varchar(500)"`
+	Type    commonType.AvatarType `gorm:"column:type;not null"`
+	AdminId uint                  `gorm:"column:admin_id"`
+}
+
+func (m *Avatar) GetName() string {
+	return "avatars"
+}

--- a/backend/app/models/category_model.go
+++ b/backend/app/models/category_model.go
@@ -8,4 +8,5 @@ type Category struct {
 	PortfolioId uint   `gorm:"column:portfolio_id;not null"`
 	Name        string `gorm:"column:name;type:varchar(100);not null"`
 	Type        string `gorm:"column:type;type:enum('income', 'expense');not null"`
+	AdminId     *uint  `gorm:"column:admin_id"`
 }

--- a/backend/app/models/portfolio_model.go
+++ b/backend/app/models/portfolio_model.go
@@ -5,9 +5,14 @@ import "gorm.io/gorm"
 type Portfolio struct {
 	gorm.Model
 	Name                 string                 `gorm:"column:name;not null"`
-	UserId               string                 `gorm:"column:user_id"`
-	Account              []Account              `gorm:"foreignKey:portfolio_id"`
-	Budget               []Budget               `gorm:"foreignKey:portfolio_id"`
-	Transaction          []Transaction          `gorm:"foreignKey:portfolio_id"`
-	RecurringTransaction []RecurringTransaction `gorm:"foreignKey:portfolio_id"`
+	UserId               uint                   `gorm:"column:user_id"`
+	AvatarId             uint                   `gorm:"column:avatar_id"`
+	Account              []Account              `gorm:"foreignKey:PortfolioId;constraint:OnDelete:CASCADE;"`
+	Budget               []Budget               `gorm:"foreignKey:PortfolioId;constraint:OnDelete:CASCADE;"`
+	Transaction          []Transaction          `gorm:"foreignKey:PortfolioId;constraint:OnDelete:CASCADE;"`
+	RecurringTransaction []RecurringTransaction `gorm:"foreignKey:PortfolioId;constraint:OnDelete:CASCADE;"`
+}
+
+func (m Portfolio) GetName() string {
+	return "portfolios"
 }

--- a/backend/app/models/transaction.go
+++ b/backend/app/models/transaction.go
@@ -6,12 +6,12 @@ import (
 
 type Transaction struct {
 	gorm.Model
-	AccountId         uint    `gorm:"column:account_id;not null"`
-	TransferAccountId *uint   `gorm:"column:transfer_account_id;"`
-	CategoryId        uint    `gorm:"column:category_id;not null"`
-	PortfolioId       uint    `gorm:"column:portfolio_id;not null"`
-	Amount            float64 `gorm:"column:amount;type:decimal(15,2);not null"`
-	Type              string  `gorm:"column:type;type:enum('income', 'expense', 'transfer');not null"`
-	Description       string  `gorm:"column:description;type:varchar(255)"`
-	Log               []Log   `gorm:"foreignKey:transaction_id"`
+	AccountId         uint               `gorm:"column:account_id;not null"`
+	TransferAccountId *uint              `gorm:"column:transfer_account_id;"`
+	CategoryId        uint               `gorm:"column:category_id;not null"`
+	PortfolioId       uint               `gorm:"column:portfolio_id;not null"`
+	Amount            float64            `gorm:"column:amount;type:decimal(15,2);not null"`
+	Type              string             `gorm:"column:type;type:enum('income', 'expense', 'transfer');not null"`
+	Description       string             `gorm:"column:description;type:varchar(255)"`
+	TransactionAudit  []TransactionAudit `gorm:"foreignKey:TransactionId;constraint:OnDelete:CASCADE;"`
 }

--- a/backend/app/models/transaction_audit_model.go
+++ b/backend/app/models/transaction_audit_model.go
@@ -2,7 +2,7 @@ package models
 
 import "gorm.io/gorm"
 
-type Log struct {
+type TransactionAudit struct {
 	gorm.Model
 	UserId        *uint  `gorm:"column:user_id;"`        // Nullable for system actions
 	TransactionId *uint  `gorm:"column:transaction_id;"` // Nullable for system actions

--- a/backend/app/models/user_model.go
+++ b/backend/app/models/user_model.go
@@ -4,11 +4,14 @@ import "gorm.io/gorm"
 
 type User struct {
 	gorm.Model
-	Name         string      `gorm:"column:name;type:varchar(30);not null"`
-	Email        string      `gorm:"column:email;type:varchar(100);unique;not null"`
-	Username     string      `gorm:"column:username;type:varchar(20);unique;not null"`
-	MobileNumber string      `gorm:"column:mobile_number;type:varchar(12);unique;not null"`
-	Password     string      `gorm:"column:password;type:varchar(100);not null"`
-	Portfolio    []Portfolio `gorm:"foreignKey:user_id"`
-	Log          []Log       `gorm:"foreignKey:user_id"`
+	Name             string             `gorm:"column:name;type:varchar(30);not null"`
+	Email            string             `gorm:"column:email;type:varchar(100);unique;not null"`
+	Username         string             `gorm:"column:username;type:varchar(20);unique;not null"`
+	MobileNumber     string             `gorm:"column:mobile_number;type:varchar(12);unique;not null"`
+	Password         string             `gorm:"column:password;type:varchar(100);not null"`
+	AvatarId         uint               `gorm:"column:avatar_id"`
+	Portfolio        []Portfolio        `gorm:"foreignKey:UserId;constraint:OnDelete:CASCADE;"`
+	TransactionAudit []TransactionAudit `gorm:"foreignKey:UserId;constraint:OnDelete:CASCADE;"`
+	Account          []Account          `gorm:"foreignKey:UserId;constraint:OnDelete:CASCADE;"`
+	Category         []Category         `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;"`
 }

--- a/backend/app/repository/avatar_repository.go
+++ b/backend/app/repository/avatar_repository.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+)
+
+type Avatar struct {
+	container *storage.Container
+}
+
+func NewAvatar(container *storage.Container) *Avatar {
+	return &Avatar{
+		container: container,
+	}
+}
+
+func (repo *Avatar) GetAvatar(id uint, avatar *models.Avatar) error {
+	if err := repo.container.Config.ReadOnlyDB.Where("id = ?", id).First(avatar).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/app/repository/portfolio_repository.go
+++ b/backend/app/repository/portfolio_repository.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"errors"
+
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+)
+
+type Portfolio struct {
+	container *storage.Container
+}
+
+func NewPortfolio(container *storage.Container) *Portfolio {
+	return &Portfolio{
+		container: container,
+	}
+}
+
+func (repo *Portfolio) GetList(userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error) {
+	var portfolio models.Portfolio
+	var avatar models.Avatar
+
+	var portfolios []responses.PortfolioResponse
+
+	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName() + " p").
+		Joins("JOIN " + avatar.GetName() + " a ON a.id = p.avatar_id")
+	if userType == commonType.User {
+		query.Where("p.user_id = ?", userId)
+	}
+	err := query.Select("p.id, p.name, a.id as avatar_id, a.url").
+		Scan(&portfolios).Error
+
+	if err != nil {
+		return nil, err // Other errors
+	}
+	return &portfolios, nil
+}
+
+func (repo *Portfolio) Get(id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error) {
+	var portfolio models.Portfolio
+	var avatar models.Avatar
+
+	var portfolios responses.PortfolioResponse
+
+	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName() + " p").
+		Joins("JOIN " + avatar.GetName() + " a ON a.id = p.avatar_id")
+	if userType == commonType.User {
+		query.Where("p.user_id = ?", userId)
+	}
+	err := query.Select("p.id, p.name, a.id as avatar_id, a.url").
+		Scan(&portfolios).Error
+
+	if err != nil {
+		return nil, err // Other errors
+	}
+	return &portfolios, nil
+}
+
+func (repo *Portfolio) Add(portfolio models.Portfolio) error {
+	return repo.container.Config.ReadOnlyDB.Create(portfolio).Error
+}
+
+func (repo *Portfolio) Update(id, userId uint, portfolio models.Portfolio) error {
+	result := repo.container.Config.ReadWriteDB.Model(&models.Portfolio{}).
+		Where("id = ? AND user_id = ?", id, userId).
+		Updates(portfolio)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("Portfolio not found!")
+	}
+	return nil
+}
+
+func (repo *Portfolio) Delete(id, userId uint) error {
+	result := repo.container.Config.ReadOnlyDB.Where("id = ? AND user_id = ?", id, userId).Delete(models.Portfolio{})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("Portfolio not found!")
+	}
+	return nil
+}

--- a/backend/app/requests/portfolio_request.go
+++ b/backend/app/requests/portfolio_request.go
@@ -1,0 +1,21 @@
+package requests
+
+import (
+	"errors"
+)
+
+// Portfolio payload
+type PortfolioRequest struct {
+	Name     string `json:"name" binding:"required"`
+	AvatarId uint   `json:"avatar_id" binding:"required"`
+}
+
+func (r PortfolioRequest) IsValid() error {
+	if err := Validate.IsValidName(r.Name); err != nil {
+		return err
+	}
+	if !Validate.IsValidID(r.AvatarId) {
+		return errors.New("Invalid avatar id!")
+	}
+	return nil
+}

--- a/backend/app/responses/auth_response.go
+++ b/backend/app/responses/auth_response.go
@@ -1,9 +1,5 @@
 package responses
 
-type LoginResponse struct {
-	Token     string `json:"token"`
-	ExpiresAt int64  `json:"expires_at"`
-}
 type AuthResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`

--- a/backend/app/responses/avatar_response.go
+++ b/backend/app/responses/avatar_response.go
@@ -1,0 +1,6 @@
+package responses
+
+type AvatarResponse struct {
+	Id  uint   `json:"id"`
+	Url string `json:"url"`
+}

--- a/backend/app/responses/portfolio_response.go
+++ b/backend/app/responses/portfolio_response.go
@@ -1,0 +1,7 @@
+package responses
+
+type PortfolioResponse struct {
+	Id     uint           `json:"id"`
+	Name   string         `json:"name"`
+	Avatar AvatarResponse `json:"avatar"`
+}

--- a/backend/app/services/portfolio_service.go
+++ b/backend/app/services/portfolio_service.go
@@ -1,0 +1,184 @@
+package services
+
+import (
+	"errors"
+
+	"github.com/Uttamnath64/arvo-fin/app/common"
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/repository"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"gorm.io/gorm"
+)
+
+type Portfolio struct {
+	container     *storage.Container
+	portfolioRepo *repository.Portfolio
+	avatarRepo    *repository.Avatar
+}
+
+func NewPortfolio(container *storage.Container) *Portfolio {
+	return &Portfolio{
+		container:     container,
+		portfolioRepo: repository.NewPortfolio(container),
+		avatarRepo:    repository.NewAvatar(container),
+	}
+}
+
+func (service *Portfolio) GetList(userId uint, userType commonType.UserType) responses.ServiceResponse {
+
+	portfolioRes, err := service.portfolioRepo.GetList(userId, userType)
+	if err != gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "Record not found!",
+			Error:      err,
+		}
+	}
+	if err != nil {
+		service.container.Logger.Error("api.common.service.GetList", err.Error(), userId, userType)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "Portfolio records found!",
+		Data:       portfolioRes,
+	}
+}
+
+func (service *Portfolio) Get(id, userId uint, userType commonType.UserType) responses.ServiceResponse {
+
+	portfolioRes, err := service.portfolioRepo.Get(id, userId, userType)
+	if err != gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "Record not found!",
+			Error:      err,
+		}
+	}
+	if err != nil {
+		service.container.Logger.Error("api.common.service.Get", err.Error(), id, userId, userType)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "Portfolio record found!",
+		Data:       portfolioRes,
+	}
+}
+
+func (service *Portfolio) Add(payload requests.PortfolioRequest, userId uint) responses.ServiceResponse {
+
+	portfolio := models.Portfolio{
+		Name:     payload.Name,
+		AvatarId: payload.AvatarId,
+		UserId:   userId,
+	}
+
+	if err := service.avatarRepo.GetAvatar(payload.AvatarId, &models.Avatar{}); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return responses.ServiceResponse{
+				StatusCode: common.StatusValidationError,
+				Message:    "Avatar not found!",
+				Error:      err,
+			}
+		}
+
+		// Other database errors
+		service.container.Logger.Error("api.common.service.Add", err.Error(), portfolio, userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Database error while fetching avatar!",
+			Error:      err,
+		}
+	}
+
+	err := service.portfolioRepo.Add(portfolio)
+	if err != nil {
+		service.container.Logger.Error("api.common.service.Add", err.Error(), portfolio, userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "Portfolio record added!",
+	}
+}
+
+func (service *Portfolio) Update(id, userId uint, payload requests.PortfolioRequest) responses.ServiceResponse {
+
+	portfolio := models.Portfolio{
+		Name:     payload.Name,
+		AvatarId: payload.AvatarId,
+		UserId:   userId,
+	}
+
+	if err := service.avatarRepo.GetAvatar(payload.AvatarId, &models.Avatar{}); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return responses.ServiceResponse{
+				StatusCode: common.StatusValidationError,
+				Message:    "Avatar not found!",
+				Error:      err,
+			}
+		}
+
+		// Other database errors
+		service.container.Logger.Error("api.common.service.Update", err.Error(), id, userId, portfolio)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Database error while fetching avatar!",
+			Error:      err,
+		}
+	}
+
+	err := service.portfolioRepo.Update(id, userId, portfolio)
+	if err != nil {
+		service.container.Logger.Error("api.common.service.Update", err.Error(), id, userId, portfolio)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "Portfolio record updated!",
+	}
+}
+
+func (service *Portfolio) Delete(id, userId uint) responses.ServiceResponse {
+
+	err := service.portfolioRepo.Delete(id, userId)
+	if err != nil {
+		service.container.Logger.Error("api.common.service.Delete", err.Error(), id, userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "Portfolio record deleted!",
+	}
+}

--- a/backend/fin-api/internal/handlers/handler.go
+++ b/backend/fin-api/internal/handlers/handler.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/Uttamnath64/arvo-fin/app/common"
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
+	"github.com/gin-gonic/gin"
+)
+
+type userInfo struct {
+	userId   uint
+	userType commonType.UserType
+}
+
+func isErrorResponse(ctx *gin.Context, serviceResponse responses.ServiceResponse) bool {
+
+	if serviceResponse.HasError() {
+		apiResponse := responses.ApiResponse{
+			Status:  false,
+			Message: serviceResponse.Message,
+			Details: serviceResponse.Error.Error(),
+		}
+
+		switch serviceResponse.StatusCode {
+		case common.StatusNotFound:
+			ctx.JSON(http.StatusBadRequest, apiResponse)
+			break
+		case common.StatusValidationError:
+			ctx.JSON(http.StatusUnauthorized, apiResponse)
+			break
+		case common.StatusServerError:
+			ctx.JSON(http.StatusInternalServerError, apiResponse)
+			break
+		}
+		return true
+	}
+	return false
+}
+
+func bindAndValidateJson[T any](ctx *gin.Context, payload *T) bool {
+	if err := ctx.ShouldBindJSON(payload); err != nil {
+		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			Status:  false,
+			Message: "Invalid request payload. Please check the input data format!",
+			Details: err.Error(),
+		})
+		return false
+	}
+
+	// Validate only if the struct has an IsValid() method
+	if validatable, ok := interface{}(payload).(interface{ IsValid() error }); ok {
+		if err := validatable.IsValid(); err != nil {
+			ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+				Status:  false,
+				Message: err.Error(),
+			})
+			return false
+		}
+	}
+	return true
+}
+
+func getUserInfo(ctx *gin.Context) (*userInfo, bool) {
+	userId, exists := ctx.Get("userId")
+	userType, existsType := ctx.Get("userType")
+
+	// Check if values exist
+	if !exists || !existsType {
+		ctx.JSON(http.StatusUnauthorized, responses.ApiResponse{
+			Status:  false,
+			Message: "Unauthorized",
+		})
+		return nil, false
+	}
+	return &userInfo{
+		userId:   userId.(uint),
+		userType: userType.(commonType.UserType),
+	}, true
+}

--- a/backend/fin-api/internal/handlers/portfolio_handler.go
+++ b/backend/fin-api/internal/handlers/portfolio_handler.go
@@ -1,0 +1,173 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/services"
+	"github.com/gin-gonic/gin"
+)
+
+type Portfolio struct {
+	container        *storage.Container
+	portfolioService *services.Portfolio
+}
+
+func NewPortfolio(container *storage.Container) *Portfolio {
+	return &Portfolio{
+		container:        container,
+		portfolioService: services.NewPortfolio(container),
+	}
+}
+
+func (handler *Portfolio) GetList(ctx *gin.Context) {
+
+	userInfo, ok := getUserInfo(ctx)
+	if !ok {
+		return
+	}
+
+	serviceResponse := handler.portfolioService.GetList(userInfo.userId, userInfo.userType)
+	if isErrorResponse(ctx, serviceResponse) {
+		return
+	}
+
+	portfolioResponse, _ := serviceResponse.Data.([]responses.PortfolioResponse)
+	ctx.JSON(http.StatusOK, responses.ApiResponse{
+		Status:   true,
+		Message:  serviceResponse.Message,
+		Metadata: portfolioResponse,
+	})
+}
+
+func (handler *Portfolio) Get(ctx *gin.Context) {
+
+	userInfo, ok := getUserInfo(ctx)
+	if !ok {
+		return
+	}
+
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil || id <= 0 {
+		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			Status:  false,
+			Message: "Invalid portfolio id!",
+		})
+		return
+	}
+
+	serviceResponse := handler.portfolioService.Get(uint(id), userInfo.userId, userInfo.userType)
+	if isErrorResponse(ctx, serviceResponse) {
+		return
+	}
+
+	portfolioResponse, _ := serviceResponse.Data.(responses.PortfolioResponse)
+	ctx.JSON(http.StatusOK, responses.ApiResponse{
+		Status:   true,
+		Message:  serviceResponse.Message,
+		Metadata: portfolioResponse,
+	})
+}
+
+func (handler *Portfolio) Add(ctx *gin.Context) {
+
+	var payload requests.PortfolioRequest
+	if !bindAndValidateJson(ctx, &payload) {
+		return
+	}
+
+	userInfo, ok := getUserInfo(ctx)
+	if !ok {
+		return
+	}
+	if userInfo.userType != commonType.User {
+		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+			Status:  false,
+			Message: "Only users can add portfolios!",
+		})
+	}
+
+	serviceResponse := handler.portfolioService.Add(payload, userInfo.userId)
+	if isErrorResponse(ctx, serviceResponse) {
+		return
+	}
+
+	ctx.JSON(http.StatusOK, responses.ApiResponse{
+		Status:  true,
+		Message: serviceResponse.Message,
+	})
+}
+
+func (handler *Portfolio) Update(ctx *gin.Context) {
+
+	var payload requests.PortfolioRequest
+	if !bindAndValidateJson(ctx, &payload) {
+		return
+	}
+
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil || id <= 0 {
+		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			Status:  false,
+			Message: "Invalid portfolio id!",
+		})
+		return
+	}
+
+	userInfo, ok := getUserInfo(ctx)
+	if !ok {
+		return
+	}
+	if userInfo.userType != commonType.User {
+		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+			Status:  false,
+			Message: "You are not allowed to update this portfolio!",
+		})
+	}
+
+	serviceResponse := handler.portfolioService.Update(uint(id), userInfo.userId, payload)
+	if isErrorResponse(ctx, serviceResponse) {
+		return
+	}
+
+	ctx.JSON(http.StatusOK, responses.ApiResponse{
+		Status:  true,
+		Message: serviceResponse.Message,
+	})
+}
+
+func (handler *Portfolio) Delete(ctx *gin.Context) {
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil || id <= 0 {
+		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			Status:  false,
+			Message: "Invalid portfolio id!",
+		})
+		return
+	}
+
+	userInfo, ok := getUserInfo(ctx)
+	if !ok {
+		return
+	}
+	if userInfo.userType != commonType.User {
+		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+			Status:  false,
+			Message: "You are not authorized to delete a portfolio!",
+		})
+	}
+
+	serviceResponse := handler.portfolioService.Delete(uint(id), userInfo.userId)
+	if isErrorResponse(ctx, serviceResponse) {
+		return
+	}
+
+	ctx.JSON(http.StatusOK, responses.ApiResponse{
+		Status:  true,
+		Message: serviceResponse.Message,
+	})
+}

--- a/backend/fin-api/internal/routes/portfolio_route.go
+++ b/backend/fin-api/internal/routes/portfolio_route.go
@@ -1,0 +1,19 @@
+package routes
+
+import (
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/handlers"
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/middleware"
+)
+
+func (routes *Routes) PortfolioRoutes() {
+	portfolioHandler := handlers.NewPortfolio(routes.container)
+	middle := middleware.New(routes.container)
+	userGroup := routes.server.Group("/portfolio").Use(middle.Middleware())
+	{
+		userGroup.GET("/", portfolioHandler.GetList)
+		userGroup.GET("/:id", portfolioHandler.Get)
+		userGroup.POST("/", portfolioHandler.Add)
+		userGroup.PUT("/:id", portfolioHandler.Update)
+		userGroup.DELETE("/:id", portfolioHandler.Delete)
+	}
+}

--- a/backend/fin-api/internal/services/portfolio_service.go
+++ b/backend/fin-api/internal/services/portfolio_service.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
+	commonServices "github.com/Uttamnath64/arvo-fin/app/services"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+)
+
+type Portfolio struct {
+	container        *storage.Container
+	portfolioService *commonServices.Portfolio
+}
+
+func NewPortfolio(container *storage.Container) *Portfolio {
+	return &Portfolio{
+		container:        container,
+		portfolioService: commonServices.NewPortfolio(container),
+	}
+}
+
+func (service *Portfolio) GetList(userId uint, userType commonType.UserType) responses.ServiceResponse {
+	return service.portfolioService.GetList(userId, userType)
+}
+
+func (service *Portfolio) Get(id, userId uint, userType commonType.UserType) responses.ServiceResponse {
+	return service.portfolioService.Get(id, userId, userType)
+}
+
+func (service *Portfolio) Add(payload requests.PortfolioRequest, userId uint) responses.ServiceResponse {
+	return service.portfolioService.Add(payload, userId)
+}
+
+func (service *Portfolio) Update(id, userId uint, payload requests.PortfolioRequest) responses.ServiceResponse {
+	return service.portfolioService.Update(id, userId, payload)
+}
+
+func (service *Portfolio) Delete(id, userId uint) responses.ServiceResponse {
+	return service.portfolioService.Delete(id, userId)
+}

--- a/backend/pkg/validater/validater.go
+++ b/backend/pkg/validater/validater.go
@@ -93,6 +93,10 @@ func (v *Validater) IsValidMobileNumber(data string) error {
 	return nil
 }
 
+func (v *Validater) IsValidID(id uint) bool {
+	return id > 0
+}
+
 func (v *Validater) HashPassword(password string) (string, error) {
 	hashPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {


### PR DESCRIPTION
New API endpoints for portfolio management and includes several improvements:

### New APIs (/portfolio)

1. GET /portfolio → Fetch a single portfolio
2. GET /portfolio/list → Fetch a list of portfolios
3. POST /portfolio → Add a new portfolio
4. PUT /portfolio → Update an existing portfolio
5. DELETE /portfolio → Delete a portfolio

### Changes & Enhancements

1. Added a new table for portfolio data.
2. Improved model tables for better structure and efficiency.
3. Refactored code:
 - Improved service layer to better handle business logic.
 - Enhanced error handling and input validation.
 - Optimized database interactions with GORM.