### PR TITLE
add api me/, me/setting

### DIFF
--- a/backend/app/repository/currency_repository.go
+++ b/backend/app/repository/currency_repository.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+)
+
+type Currency struct {
+	container *storage.Container
+}
+
+func NewCurrency(container *storage.Container) *Currency {
+	return &Currency{
+		container: container,
+	}
+}
+
+func (repo *Currency) CodeExists(code string) (bool, error) {
+	var count int64
+
+	err := repo.container.Config.ReadOnlyDB.Model(&models.Currency{}).
+		Where("code = ?", code).Count(&count).Error
+
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}

--- a/backend/app/repository/currency_repository_mock.go
+++ b/backend/app/repository/currency_repository_mock.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"gorm.io/gorm"
+)
+
+type TestCurrency struct {
+	container *storage.Container
+}
+
+func NewTestCurrency(container *storage.Container) *Currency {
+	return &Currency{
+		container: container,
+	}
+}
+
+func (repo *TestCurrency) CodeExists(code string) (bool, error) {
+	if code != "INR" {
+		return false, gorm.ErrRecordNotFound
+	}
+	return true, nil
+}

--- a/backend/app/repository/portfolio_repository.go
+++ b/backend/app/repository/portfolio_repository.go
@@ -28,7 +28,7 @@ func (repo *Portfolio) GetList(userId uint, userType commonType.UserType) (*[]re
 	var portfolios []responses.PortfolioResponse
 
 	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName() + " p").
-		Joins("JOIN " + avatar.GetName() + " a ON a.id = p.avatar_id").Where("p.deleted_at IS NULL")
+		Joins("JOIN " + avatar.GetName() + " a ON a.id = p.avatar_id")
 	if userType == commonType.UserTypeUser {
 		query = query.Where("p.user_id = ? ", userId)
 	}
@@ -51,7 +51,7 @@ func (repo *Portfolio) Get(id, userId uint, userType commonType.UserType) (*resp
 	var portfolios responses.PortfolioResponse
 
 	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName()+" p").
-		Joins("JOIN "+avatar.GetName()+" a ON a.id = p.avatar_id").Where("p.id = ? AND p.deleted_at IS NULL", id)
+		Joins("JOIN "+avatar.GetName()+" a ON a.id = p.avatar_id").Where("p.id = ?", id)
 	if userType == commonType.UserTypeUser {
 		query = query.Where("p.user_id = ?", userId)
 	}

--- a/backend/app/repository/repository.go
+++ b/backend/app/repository/repository.go
@@ -35,4 +35,12 @@ type UserRepository interface {
 	CreateUser(user *models.User) (uint, error)
 	UpdatePasswordByEmail(email, newPassword string) error
 	GetUser(userId uint, user *models.User) error
+	Get(userId uint) (*responses.MeResponse, error)
+	GetSettings(userId uint) (*responses.SettingsResponse, error)
+	Update(userId uint, payload requests.MeRequest) error
+	UpdateSettings(userId uint, payload requests.SettingsRequest) error
+}
+
+type CurrencyRepository interface {
+	CodeExists(code string) (bool, error)
 }

--- a/backend/app/repository/user_repository.go
+++ b/backend/app/repository/user_repository.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 
 	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"gorm.io/gorm"
 )
 
 type User struct {
@@ -75,6 +78,85 @@ func (repo *User) UpdatePasswordByEmail(email, newPassword string) error {
 func (repo *User) GetUser(userId uint, user *models.User) error {
 	if err := repo.container.Config.ReadOnlyDB.Where("id = ?", userId).First(user).Error; err != nil {
 		return err
+	}
+	return nil
+}
+
+func (repo *User) Get(userId uint) (*responses.MeResponse, error) {
+	var user models.User
+	var avatar models.Avatar
+	var response responses.MeResponse
+
+	query := repo.container.Config.ReadOnlyDB.Table(user.GetName()+" u").
+		Joins("JOIN "+avatar.GetName()+" a ON a.id = u.avatar_id").Where("u.id = ?", userId)
+
+	err := query.Select("u.id, u.name, u.username, u.email, a.id as avatar_id, a.icon as avatar_icon").
+		Scan(&response).Error
+
+	if err != nil {
+		return nil, err // Other errors
+	}
+	if response.Id == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &response, nil
+}
+
+func (repo *User) GetSettings(userId uint) (*responses.SettingsResponse, error) {
+
+	var user models.User
+	var currency models.Currency
+	var response responses.SettingsResponse
+
+	err := repo.container.Config.ReadOnlyDB.Table(user.GetName()+" u").
+		Joins("JOIN "+currency.GetName()+" c ON c.code = u.currency_code").Where("u.id = ?", userId).
+		Select("u.id, u.decimal_places, u.number_format, u.email_notifications, c.code AS 'currency_code', c.symbol AS 'currency_symbol', c.name AS 'currency_name'").
+		Scan(&response).Error
+
+	if err != nil {
+		return nil, err // Other errors
+	}
+	if response.Id == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &response, nil
+}
+
+func (repo *User) Update(userId uint, payload requests.MeRequest) error {
+	result := repo.container.Config.ReadWriteDB.Model(&models.User{}).
+		Where("id = ?", userId).
+		Updates(map[string]interface{}{
+			"name":      payload.Name,
+			"username":  payload.Username,
+			"avatar_id": payload.AvatarId,
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("User not found!")
+	}
+	return nil
+}
+
+func (repo *User) UpdateSettings(userId uint, payload requests.SettingsRequest) error {
+	result := repo.container.Config.ReadWriteDB.Model(&models.User{}).
+		Where("id = ?", userId).
+		Updates(map[string]interface{}{
+			"currency_code":       payload.CurrencyCode,
+			"number_format":       payload.NumberFormat,
+			"decimal_places":      payload.DecimalPlaces,
+			"email_notifications": payload.EmailNotifications,
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("User not found!")
 	}
 	return nil
 }

--- a/backend/app/repository/user_repository_mock.go
+++ b/backend/app/repository/user_repository_mock.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
 )
@@ -71,6 +73,47 @@ func (repo *TestUser) GetUser(userId uint, user *models.User) error {
 		Email:    "uttam@example.com",
 		Username: "uttam.nath",
 		Password: "$2a$10$N7RKD8VqYHY4kbGWmfElBOs/wPfdnGldKAoRGOPa7ERbxEzeEOl1u",
+	}
+	return nil
+}
+
+func (repo *TestUser) Get(userId uint) (*responses.MeResponse, error) {
+	if userId != 1 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &responses.MeResponse{
+		Id:         1,
+		Name:       "uttam.nath",
+		AvatarID:   8,
+		AvatarIcon: "🧑",
+	}, nil
+}
+
+func (repo *TestUser) GetSettings(userId uint) (*responses.SettingsResponse, error) {
+	if userId != 1 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &responses.SettingsResponse{
+		Id:                 1,
+		DecimalPlaces:      3,
+		NumberFormat:       1,
+		EmailNotifications: true,
+		CurrencyCode:       "INR",
+		CurrencyName:       "India",
+		CurrencySymbol:     "₹",
+	}, nil
+}
+
+func (repo *TestUser) Update(userId uint, payload requests.MeRequest) error {
+	if userId != 1 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func (repo *TestUser) UpdateSettings(userId uint, payload requests.SettingsRequest) error {
+	if userId != 1 {
+		return gorm.ErrRecordNotFound
 	}
 	return nil
 }

--- a/backend/app/requests/me_request.go
+++ b/backend/app/requests/me_request.go
@@ -30,8 +30,7 @@ type SettingsRequest struct {
 	CurrencyCode       string                   `json:"currency_code" binding:"required"`
 	DecimalPlaces      commonType.DecimalPlaces `json:"decimal_places" binding:"required"`
 	NumberFormat       commonType.NumberFormat  `json:"number_format" binding:"required"`
-	RemindEveryday     bool                     `json:"remind_everyday" binding:"required"`
-	MonthlyReportEmail bool                     `json:"monthly_report_email" binding:"required"`
+	EmailNotifications bool                     `json:"email_notifications" binding:"required"`
 }
 
 func (r SettingsRequest) IsValid() error {

--- a/backend/app/responses/me_response.go
+++ b/backend/app/responses/me_response.go
@@ -1,15 +1,20 @@
 package responses
 
 type MeResponse struct {
-	Id        uint   `json:"id"`
-	Name      string `json:"name"`
-	AvatarID  uint   `json:"avatar_id"`
-	AvatarURL string `json:"url"`
+	Id         uint   `json:"id"`
+	Name       string `json:"name"`
+	Username   string `json:"username"`
+	Email      string `json:"emil"`
+	AvatarID   uint   `json:"avatar_id"`
+	AvatarIcon string `json:"avatar_icon"`
 }
 
 type SettingsResponse struct {
-	Id        uint   `json:"id"`
-	Name      string `json:"name"`
-	AvatarID  uint   `json:"avatar_id"`
-	AvatarURL string `json:"url"`
+	Id                 uint   `json:"id"`
+	DecimalPlaces      int    `json:"decimal_places"`
+	NumberFormat       int    `json:"number_format"`
+	EmailNotifications bool   `json:"email_notifications"`
+	CurrencyCode       string `json:"currency_code"`
+	CurrencySymbol     string `json:"currency_symbol"`
+	CurrencyName       string `json:"currency_name"`
 }

--- a/backend/app/services/service.go
+++ b/backend/app/services/service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/Uttamnath64/arvo-fin/pkg/validater"
 )
@@ -26,4 +27,8 @@ type PortfolioService interface {
 }
 
 type UserService interface {
+	Get(userId uint) responses.ServiceResponse
+	GetSettings(userId uint) responses.ServiceResponse
+	Update(payload requests.MeRequest, userId uint) responses.ServiceResponse
+	UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse
 }

--- a/backend/app/services/user_service.go
+++ b/backend/app/services/user_service.go
@@ -1,18 +1,155 @@
 package services
 
 import (
+	"github.com/Uttamnath64/arvo-fin/app/common"
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+	"github.com/Uttamnath64/arvo-fin/app/models"
 	"github.com/Uttamnath64/arvo-fin/app/repository"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"gorm.io/gorm"
 )
 
 type User struct {
-	container *storage.Container
-	repo      repository.UserRepository
+	container    *storage.Container
+	repoUser     repository.UserRepository
+	repoAvatar   repository.AvatarRepository
+	repoCurrency repository.CurrencyRepository
 }
 
-func NewUserService(container *storage.Container) *User {
+func NewUser(container *storage.Container) *User {
 	return &User{
-		container: container,
-		repo:      repository.NewUser(container),
+		container:    container,
+		repoUser:     repository.NewUser(container),
+		repoAvatar:   repository.NewAvatar(container),
+		repoCurrency: repository.NewCurrency(container),
+	}
+}
+
+func (service *User) Get(userId uint) responses.ServiceResponse {
+	response, err := service.repoUser.Get(userId)
+	if err == gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "User not found!",
+			Error:      err,
+		}
+	}
+
+	if err != nil {
+		service.container.Logger.Error("auth.service.user-Get", err.Error(), userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "User records found!",
+		Data:       response,
+	}
+}
+
+func (service *User) GetSettings(userId uint) responses.ServiceResponse {
+	response, err := service.repoUser.GetSettings(userId)
+	if err == gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "User not found!",
+			Error:      err,
+		}
+	}
+
+	if err != nil {
+		service.container.Logger.Error("auth.service.user-GetSettings", err.Error(), userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "User records found!",
+		Data:       response,
+	}
+}
+
+func (service *User) Update(payload requests.MeRequest, userId uint) responses.ServiceResponse {
+	var avatar models.Avatar
+
+	err := service.repoAvatar.GetAvatarByType(payload.AvatarId, commonType.AvatarTypeUser, &avatar)
+	if err != nil {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "Avatar not found!",
+			Error:      err,
+		}
+	}
+
+	err = service.repoUser.Update(userId, payload)
+	if err == gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "User not found!",
+			Error:      err,
+		}
+	}
+
+	if err != nil {
+		service.container.Logger.Error("auth.service.user-GetSettings", err.Error(), userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "User records updated!",
+	}
+}
+
+func (service *User) UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
+
+	ok, err := service.repoCurrency.CodeExists(payload.CurrencyCode)
+	if !ok || err != nil {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "Currency not found!",
+			Error:      err,
+		}
+	}
+
+	err = service.repoUser.UpdateSettings(userId, payload)
+	if err == gorm.ErrRecordNotFound {
+		return responses.ServiceResponse{
+			StatusCode: common.StatusNotFound,
+			Message:    "User not found!",
+			Error:      err,
+		}
+	}
+
+	if err != nil {
+		service.container.Logger.Error("auth.service.user-GetSettings", err.Error(), userId)
+		return responses.ServiceResponse{
+			StatusCode: common.StatusServerError,
+			Message:    "Oops! Something went wrong. Please try again later.",
+			Error:      err,
+		}
+	}
+
+	// Response
+	return responses.ServiceResponse{
+		StatusCode: common.StatusSuccess,
+		Message:    "User setting updated!",
 	}
 }

--- a/backend/app/services/user_service_mock.go
+++ b/backend/app/services/user_service_mock.go
@@ -1,0 +1,15 @@
+package services
+
+import (
+	"github.com/Uttamnath64/arvo-fin/app/repository"
+	"github.com/Uttamnath64/arvo-fin/app/storage"
+)
+
+func NewTestUser(container *storage.Container) *User {
+	return &User{
+		container:    container,
+		repoUser:     repository.NewTestUser(container),
+		repoAvatar:   repository.NewTestAvatar(container),
+		repoCurrency: repository.NewTestCurrency(container),
+	}
+}

--- a/backend/fin-api/internal/handlers/me_handler.go
+++ b/backend/fin-api/internal/handlers/me_handler.go
@@ -50,11 +50,11 @@ func (handler *Me) Get(ctx *gin.Context) {
 		return
 	}
 
-	portfolioResponse, _ := serviceResponse.Data.(*responses.MeResponse)
+	response, _ := serviceResponse.Data.(*responses.MeResponse)
 	ctx.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
-		Metadata: portfolioResponse,
+		Metadata: response,
 	})
 }
 
@@ -84,17 +84,17 @@ func (handler *Me) GetSettings(ctx *gin.Context) {
 		return
 	}
 
-	portfolioResponse, _ := serviceResponse.Data.(*responses.MeResponse)
+	response, _ := serviceResponse.Data.(*responses.SettingsResponse)
 	ctx.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
-		Metadata: portfolioResponse,
+		Metadata: response,
 	})
 }
 
 func (handler *Me) Update(ctx *gin.Context) {
 
-	var payload requests.SettingsRequest
+	var payload requests.MeRequest
 	if !bindAndValidateJson(ctx, &payload) {
 		return
 	}

--- a/backend/fin-api/internal/routes/me_route.go
+++ b/backend/fin-api/internal/routes/me_route.go
@@ -1,10 +1,14 @@
 package routes
 
-import "github.com/Uttamnath64/arvo-fin/fin-api/internal/handlers"
+import (
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/handlers"
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/middleware"
+)
 
 func (routes *Routes) MeRoutes() {
 	handler := handlers.NewMe(routes.container)
-	userGroup := routes.server.Group("/me")
+	middle := middleware.New(routes.container)
+	userGroup := routes.server.Group("/me").Use(middle.Middleware())
 	{
 		userGroup.GET("/", handler.Get)
 		userGroup.GET("/settings", handler.GetSettings)

--- a/backend/fin-api/internal/services/auth_service_test.go
+++ b/backend/fin-api/internal/services/auth_service_test.go
@@ -29,7 +29,7 @@ func NewTestAuth() (*Auth, bool) {
 	}, true
 }
 
-func TestLogin(t *testing.T) {
+func TestLogin_Auth(t *testing.T) {
 	authService, ok := NewTestAuth()
 	if !ok {
 		return
@@ -67,7 +67,7 @@ func TestLogin(t *testing.T) {
 	}
 }
 
-func TestRegister(t *testing.T) {
+func TestRegister_Auth(t *testing.T) {
 	authService, ok := NewTestAuth()
 	if !ok {
 		return
@@ -113,7 +113,7 @@ func TestRegister(t *testing.T) {
 	}
 }
 
-func TestSentOTP(t *testing.T) {
+func TestSentOTP_Auth(t *testing.T) {
 	authService, ok := NewTestAuth()
 	if !ok {
 		return
@@ -143,7 +143,7 @@ func TestSentOTP(t *testing.T) {
 	}
 }
 
-func TestResetPassword(t *testing.T) {
+func TestResetPassword_Auth(t *testing.T) {
 	authService, ok := NewTestAuth()
 	if !ok {
 		return
@@ -201,7 +201,7 @@ func TestResetPassword(t *testing.T) {
 	}
 }
 
-func TestGetToken(t *testing.T) {
+func TestGetToken_Auth(t *testing.T) {
 	authService, ok := NewTestAuth()
 	if !ok {
 		return

--- a/backend/fin-api/internal/services/portfolio_service_test.go
+++ b/backend/fin-api/internal/services/portfolio_service_test.go
@@ -24,7 +24,7 @@ func NewTestPortfolio() (*Portfolio, bool) {
 	}, true
 }
 
-func TestGetList(t *testing.T) {
+func TestGetList_Portfolio(t *testing.T) {
 	portfolioService, ok := NewTestPortfolio()
 	if !ok {
 		return
@@ -59,7 +59,7 @@ func TestGetList(t *testing.T) {
 	}
 }
 
-func TestGet(t *testing.T) {
+func TestGet_Portfolio(t *testing.T) {
 	portfolioService, ok := NewTestPortfolio()
 	if !ok {
 		return
@@ -97,7 +97,7 @@ func TestGet(t *testing.T) {
 	}
 }
 
-func TestAdd(t *testing.T) {
+func TestAdd_Portfolio(t *testing.T) {
 	portfolioService, ok := NewTestPortfolio()
 	if !ok {
 		return
@@ -139,7 +139,7 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-func TestUpdate(t *testing.T) {
+func TestUpdate_Portfolio(t *testing.T) {
 	portfolioService, ok := NewTestPortfolio()
 	if !ok {
 		return
@@ -183,7 +183,7 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
-func TestDelete(t *testing.T) {
+func TestDelete_Portfolio(t *testing.T) {
 	portfolioService, ok := NewTestPortfolio()
 	if !ok {
 		return

--- a/backend/fin-api/internal/services/user_service.go
+++ b/backend/fin-api/internal/services/user_service.go
@@ -1,36 +1,36 @@
 package services
 
 import (
-	"github.com/Uttamnath64/arvo-fin/app/repository"
 	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/responses"
+	"github.com/Uttamnath64/arvo-fin/app/services"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 )
 
 type User struct {
-	container *storage.Container
-	userRepo  repository.UserRepository
+	container   *storage.Container
+	userService services.UserService
 }
 
 func NewUser(container *storage.Container) *User {
 	return &User{
-		container: container,
-		userRepo:  repository.NewUser(container),
+		container:   container,
+		userService: services.NewUser(container),
 	}
 }
 
 func (service *User) Get(userId uint) responses.ServiceResponse {
-	return responses.ServiceResponse{}
+	return service.userService.Get(userId)
 }
 
 func (service *User) GetSettings(userId uint) responses.ServiceResponse {
-	return responses.ServiceResponse{}
+	return service.userService.GetSettings(userId)
 }
 
-func (service *User) Update(payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
-	return responses.ServiceResponse{}
+func (service *User) Update(payload requests.MeRequest, userId uint) responses.ServiceResponse {
+	return service.userService.Update(payload, userId)
 }
 
 func (service *User) UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
-	return responses.ServiceResponse{}
+	return service.userService.UpdateSettings(payload, userId)
 }

--- a/backend/fin-api/internal/services/user_service_test.go
+++ b/backend/fin-api/internal/services/user_service_test.go
@@ -1,13 +1,174 @@
 package services
 
 import (
-	"github.com/Uttamnath64/arvo-fin/app/repository"
-	"github.com/Uttamnath64/arvo-fin/app/storage"
+	"testing"
+
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/Uttamnath64/arvo-fin/app/services"
+	"github.com/stretchr/testify/assert"
 )
 
-func NewTestUser(container *storage.Container) *User {
+func NewTestUser() (*User, bool) {
+	container, ok := getTestContainer()
+	if !ok {
+		return nil, false
+	}
 	return &User{
-		container: container,
-		userRepo:  repository.NewTestUser(container),
+		container:   container,
+		userService: services.NewTestUser(container),
+	}, true
+}
+
+func TestGet_User(t *testing.T) {
+	userService, ok := NewTestUser()
+	if !ok {
+		return
+	}
+
+	tests := []struct {
+		name        string
+		userId      uint
+		expectError bool
+	}{
+		{
+			name:        "Valid",
+			userId:      1,
+			expectError: false,
+		},
+		{
+			name:        "Not Found",
+			userId:      10,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serviceResponse := userService.Get(tt.userId)
+			assert.Equal(t, tt.expectError, serviceResponse.HasError())
+		})
+	}
+}
+
+func TestGetSetting_User(t *testing.T) {
+	userService, ok := NewTestUser()
+	if !ok {
+		return
+	}
+
+	tests := []struct {
+		name        string
+		userId      uint
+		expectError bool
+	}{
+		{
+			name:        "Valid",
+			userId:      1,
+			expectError: false,
+		},
+		{
+			name:        "Not Found",
+			userId:      10,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serviceResponse := userService.GetSettings(tt.userId)
+			assert.Equal(t, tt.expectError, serviceResponse.HasError())
+		})
+	}
+}
+
+func TestUpdate_User(t *testing.T) {
+	userService, ok := NewTestUser()
+	if !ok {
+		return
+	}
+
+	tests := []struct {
+		name        string
+		Id          uint
+		userId      uint
+		payload     requests.MeRequest
+		expectError bool
+	}{
+		{
+			name:   "Valid",
+			userId: 1,
+			payload: requests.MeRequest{
+				Name:     "Uttam Nath",
+				Username: "uttam.nath",
+				AvatarId: 1,
+			},
+			expectError: false,
+		},
+		{
+			name:   "Not Found",
+			userId: 10,
+			payload: requests.MeRequest{
+				Name:     "Uttam Nath",
+				Username: "uttam.nath",
+				AvatarId: 1,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serviceResponse := userService.Update(tt.payload, tt.userId)
+			assert.Equal(t, tt.expectError, serviceResponse.HasError())
+		})
+	}
+}
+
+func TestUpdateSetting_User(t *testing.T) {
+	userService, ok := NewTestUser()
+	if !ok {
+		return
+	}
+
+	tests := []struct {
+		name        string
+		Id          uint
+		userId      uint
+		payload     requests.SettingsRequest
+		expectError bool
+	}{
+		{
+			name:   "Valid",
+			userId: 1,
+			payload: requests.SettingsRequest{
+				CurrencyCode:       "INR",
+				DecimalPlaces:      3,
+				NumberFormat:       1,
+				EmailNotifications: true,
+			},
+			expectError: false,
+		},
+		{
+			name:   "Not Found",
+			userId: 10,
+			payload: requests.SettingsRequest{
+				CurrencyCode:       "INR",
+				DecimalPlaces:      3,
+				NumberFormat:       1,
+				EmailNotifications: true,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			serviceResponse := userService.UpdateSettings(tt.payload, tt.userId)
+			assert.Equal(t, tt.expectError, serviceResponse.HasError())
+		})
 	}
 }


### PR DESCRIPTION
This PR adds the `Settings` API functionality, including:

- `GET /me/` — Get settings for the logged-in user
- `PUT /me/` — Update settings for the logged-in user
- `PUT /me/settings` — Update settings for the logged-in user
- `GET /me/settings` — Get settings for the logged-in user