### PR TITLE
add request context for user info

### DIFF
--- a/backend/app/common/common.go
+++ b/backend/app/common/common.go
@@ -1,5 +1,7 @@
 package common
 
+type ctxKey string
+
 const (
 
 	// account types
@@ -46,4 +48,8 @@ const (
 	StatusServerError     = 3500 // Internal server error
 	StatusDatabaseError   = 3501 // Database error
 	StatusValidationError = 3502 // Validation error
+
+	CtxUserID    ctxKey = "user_id"
+	CtxUserType  ctxKey = "user_type"
+	CtxSessionID ctxKey = "session_id"
 )

--- a/backend/app/common/types/avatar_type.go
+++ b/backend/app/common/types/avatar_type.go
@@ -11,7 +11,7 @@ const (
 )
 
 func (t AvatarType) String() string {
-	names := [...]string{"Default", "User", "Category", "Portfolio"}
+	names := [...]string{"", "Default", "User", "Category", "Portfolio"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/common/types/frequency_type.go
+++ b/backend/app/common/types/frequency_type.go
@@ -11,7 +11,7 @@ const (
 )
 
 func (t FrequencyType) String() string {
-	names := [...]string{"Daily", "Weekly", "Monthly", "Yearly"}
+	names := [...]string{"", "Daily", "Weekly", "Monthly", "Yearly"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/common/types/otp_type.go
+++ b/backend/app/common/types/otp_type.go
@@ -9,7 +9,7 @@ const (
 )
 
 func (t OtpType) String() string {
-	names := [...]string{"Register", "ResetPassword"}
+	names := [...]string{"", "Register", "ResetPassword"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/common/types/settings_types.go
+++ b/backend/app/common/types/settings_types.go
@@ -49,7 +49,7 @@ func AllNumberFormats() []NumberFormat {
 }
 
 func (t NumberFormat) String() string {
-	names := [...]string{"First 2,10,343.20", "Second 2.10.343,20", "Third 2 10 343,20", "Fourth 2 10 343.20"}
+	names := [...]string{"", "First 2,10,343.20", "Second 2.10.343,20", "Third 2 10 343,20", "Fourth 2 10 343.20"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/common/types/transaction_type.go
+++ b/backend/app/common/types/transaction_type.go
@@ -9,7 +9,7 @@ const (
 )
 
 func (t TransactionType) String() string {
-	names := [...]string{"Income", "Expense"}
+	names := [...]string{"", "Income", "Expense"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/common/types/user_type.go
+++ b/backend/app/common/types/user_type.go
@@ -9,7 +9,7 @@ const (
 )
 
 func (t UserType) String() string {
-	names := [...]string{"User", "Admin"}
+	names := [...]string{"", "User", "Admin"}
 	if !t.IsValid() {
 		return "Unknown"
 	}

--- a/backend/app/migrations/migrations.go
+++ b/backend/app/migrations/migrations.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/Uttamnath64/arvo-fin/app/config"
@@ -14,7 +13,6 @@ import (
 func getContainer() (*storage.Container, error) {
 	var err error
 	var con config.Config
-	ctx := context.Background()
 
 	// load env
 	env, err := config.LoadEnv(".env")
@@ -30,13 +28,7 @@ func getContainer() (*storage.Container, error) {
 		return nil, err
 	}
 
-	// load redis
-	redis, err := storage.NewRedisClient(ctx, env.Server.RedisAddr, "", 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return storage.NewContainer(ctx, &con, log, redis, &env), nil
+	return storage.NewContainer(&con, log, nil, &env), nil
 }
 
 func main() {
@@ -78,5 +70,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	container.Logger.Info("app-migrate-done", "👍 Migration completed!")
+	container.Logger.Info("app-migrate-done", "message", "👍 Migration completed!")
 }

--- a/backend/app/migrations/scripts/runner.go
+++ b/backend/app/migrations/scripts/runner.go
@@ -33,12 +33,12 @@ func RunMigrations(container *storage.Container) error {
 		{"Categories", categories},
 	}
 	for _, seed := range seeds {
-		container.Logger.Info("🔄 Running migration:", seed.Name)
+		container.Logger.Info("🔄 Running migration:", "name", seed.Name)
 		if err := seed.Func(container); err != nil {
 			container.Logger.Fatal("❌ Migration failed:", seed.Name, "->", err)
 			return err // Exit early on failure
 		}
-		container.Logger.Info("✅ Migration done:", seed.Name)
+		container.Logger.Info("✅ Migration done:", "name", seed.Name)
 	}
 
 	container.Logger.Info("🎉 All migrations completed successfully.")

--- a/backend/app/repository/account_repository.go
+++ b/backend/app/repository/account_repository.go
@@ -17,10 +17,10 @@ func NewAccount(container *storage.Container) *Account {
 	}
 }
 
-func (repo *Account) GetList(portfolioId, userId uint) (*[]models.Account, error) {
+func (repo *Account) GetList(rctx *requests.RequestContext, portfolioId, userId uint) (*[]models.Account, error) {
 	var account []models.Account
 
-	if err := repo.container.Config.ReadOnlyDB.Preload("Avatar").Preload("Currency").Where("user_id = ? AND portfolio_id = ?", userId, portfolioId).
+	if err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Preload("Avatar").Preload("Currency").Where("user_id = ? AND portfolio_id = ?", userId, portfolioId).
 		Find(&account).Error; err != nil {
 		return nil, err // Other errors
 	}
@@ -30,10 +30,10 @@ func (repo *Account) GetList(portfolioId, userId uint) (*[]models.Account, error
 	return &account, nil
 }
 
-func (repo *Account) Get(id uint) (*models.Account, error) {
+func (repo *Account) Get(rctx *requests.RequestContext, id uint) (*models.Account, error) {
 	var account models.Account
 
-	if err := repo.container.Config.ReadOnlyDB.Preload("Avatar").Preload("Currency").Where("id = ?", id).
+	if err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Preload("Avatar").Preload("Currency").Where("id = ?", id).
 		First(&account).Error; err != nil {
 		return nil, err // Other errors
 	}
@@ -43,16 +43,16 @@ func (repo *Account) Get(id uint) (*models.Account, error) {
 	return &account, nil
 }
 
-func (repo *Account) Create(account models.Account) (uint, error) {
-	err := repo.container.Config.ReadWriteDB.Create(&account).Error
+func (repo *Account) Create(rctx *requests.RequestContext, account models.Account) (uint, error) {
+	err := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Create(&account).Error
 	if err != nil {
 		return 0, err
 	}
 	return account.ID, nil
 }
 
-func (repo *Account) Update(id, userId uint, payload requests.AccountUpdateRequest) error {
-	result := repo.container.Config.ReadWriteDB.Model(&models.Account{}).
+func (repo *Account) Update(rctx *requests.RequestContext, id, userId uint, payload requests.AccountUpdateRequest) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Model(&models.Account{}).
 		Where("id = ? AND user_id = ?", id, userId).
 		Updates(map[string]interface{}{
 			"name":          payload.Name,
@@ -72,8 +72,8 @@ func (repo *Account) Update(id, userId uint, payload requests.AccountUpdateReque
 	return nil
 }
 
-func (repo *Account) Delete(id, userId uint) error {
-	result := repo.container.Config.ReadWriteDB.Where("id = ? AND user_id = ?", id, userId).Delete(&models.Account{})
+func (repo *Account) Delete(rctx *requests.RequestContext, id, userId uint) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Where("id = ? AND user_id = ?", id, userId).Delete(&models.Account{})
 
 	if result.Error != nil {
 		return result.Error

--- a/backend/app/repository/account_repository_mock.go
+++ b/backend/app/repository/account_repository_mock.go
@@ -20,7 +20,7 @@ func NewTestAccount(container *storage.Container) *TestAccount {
 	}
 }
 
-func (repo *TestAccount) GetList(portfolioId, userId uint) (*[]models.Account, error) {
+func (repo *TestAccount) GetList(rctx *requests.RequestContext, portfolioId, userId uint) (*[]models.Account, error) {
 	if userId != 1 || portfolioId != 1 {
 		return nil, gorm.ErrRecordNotFound
 	}
@@ -84,7 +84,7 @@ func (repo *TestAccount) GetList(portfolioId, userId uint) (*[]models.Account, e
 	}, nil
 }
 
-func (repo *TestAccount) Get(id uint) (*models.Account, error) {
+func (repo *TestAccount) Get(rctx *requests.RequestContext, id uint) (*models.Account, error) {
 	if id != 1 {
 		return nil, gorm.ErrRecordNotFound
 	}
@@ -118,11 +118,11 @@ func (repo *TestAccount) Get(id uint) (*models.Account, error) {
 	}, nil
 }
 
-func (repo *TestAccount) Create(account models.Account) (uint, error) {
+func (repo *TestAccount) Create(rctx *requests.RequestContext, account models.Account) (uint, error) {
 	return 1, nil
 }
 
-func (repo *TestAccount) Update(id, userId uint, payload requests.AccountUpdateRequest) error {
+func (repo *TestAccount) Update(rctx *requests.RequestContext, id, userId uint, payload requests.AccountUpdateRequest) error {
 	if id != 1 || userId != 1 {
 		return gorm.ErrRecordNotFound
 	}
@@ -130,7 +130,7 @@ func (repo *TestAccount) Update(id, userId uint, payload requests.AccountUpdateR
 	return nil
 }
 
-func (repo *TestAccount) Delete(id, userId uint) error {
+func (repo *TestAccount) Delete(rctx *requests.RequestContext, id, userId uint) error {
 	if id != 1 || userId != 1 {
 		return gorm.ErrRecordNotFound
 	}

--- a/backend/app/repository/auth_repository.go
+++ b/backend/app/repository/auth_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
 	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
 )
@@ -17,38 +18,38 @@ func NewAuth(container *storage.Container) *Auth {
 	}
 }
 
-func (repo *Auth) GetSessionByUser(userId uint, userType commonType.UserType, signedToken string) (*models.Session, error) {
+func (repo *Auth) GetSessionByUser(rctx *requests.RequestContext, userId uint, userType commonType.UserType, signedToken string) (*models.Session, error) {
 	var session models.Session
-	err := repo.container.Config.ReadOnlyDB.Where("user_id = ? AND user_type = ? AND token = ?", userId, userType, signedToken).First(&session).Error
+	err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Where("user_id = ? AND user_type = ? AND token = ?", userId, userType, signedToken).First(&session).Error
 	if err != nil {
 		return nil, err
 	}
 	return &session, nil
 }
 
-func (repo *Auth) GetSessionByRefreshToken(refreshToken string, userType commonType.UserType) (*models.Session, error) {
+func (repo *Auth) GetSessionByRefreshToken(rctx *requests.RequestContext, refreshToken string, userType commonType.UserType) (*models.Session, error) {
 	var session models.Session
-	err := repo.container.Config.ReadOnlyDB.Where("refresh_token = ? AND user_type = ?", refreshToken, userType).First(&session).Error
+	err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Where("refresh_token = ? AND user_type = ?", refreshToken, userType).First(&session).Error
 	if err != nil {
 		return nil, err
 	}
 	return &session, nil
 }
 
-func (repo *Auth) CreateSession(session *models.Session) (uint, error) {
-	err := repo.container.Config.ReadWriteDB.Create(session).Error
+func (repo *Auth) CreateSession(rctx *requests.RequestContext, session *models.Session) (uint, error) {
+	err := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Create(session).Error
 	if err != nil {
 		return 0, err
 	}
 	return session.ID, nil
 }
 
-func (repo *Auth) DeleteSession(sessionID uint) error {
-	return repo.container.Config.ReadWriteDB.Unscoped().Where("id = ?", sessionID).Delete(&models.Session{}).Error
+func (repo *Auth) DeleteSession(rctx *requests.RequestContext, sessionID uint) error {
+	return repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Unscoped().Where("id = ?", sessionID).Delete(&models.Session{}).Error
 }
 
-func (repo *Auth) UpdateSession(id uint, refreshToken string, expiresAt int64) error {
-	result := repo.container.Config.ReadWriteDB.Model(&models.Session{}).
+func (repo *Auth) UpdateSession(rctx *requests.RequestContext, id uint, refreshToken string, expiresAt int64) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Model(&models.Session{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{
 			"refresh_token": refreshToken,

--- a/backend/app/repository/auth_repository_mock.go
+++ b/backend/app/repository/auth_repository_mock.go
@@ -5,6 +5,7 @@ import (
 
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
 	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
 )
@@ -19,7 +20,7 @@ func NewTestAuth(container *storage.Container) *TestAuth {
 	}
 }
 
-func (repo *TestAuth) GetSessionByUser(userId uint, userType commonType.UserType, signedToken string) (*models.Session, error) {
+func (repo *TestAuth) GetSessionByUser(rctx *requests.RequestContext, userId uint, userType commonType.UserType, signedToken string) (*models.Session, error) {
 	if userId == 1 && userType == commonType.UserTypeUser {
 		session := models.Session{
 			BaseModel: models.BaseModel{
@@ -39,7 +40,7 @@ func (repo *TestAuth) GetSessionByUser(userId uint, userType commonType.UserType
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (repo *TestAuth) GetSessionByRefreshToken(refreshToken string, userType commonType.UserType) (*models.Session, error) {
+func (repo *TestAuth) GetSessionByRefreshToken(rctx *requests.RequestContext, refreshToken string, userType commonType.UserType) (*models.Session, error) {
 	if refreshToken != "" && userType == commonType.UserTypeUser {
 		session := models.Session{
 			BaseModel: models.BaseModel{
@@ -59,14 +60,14 @@ func (repo *TestAuth) GetSessionByRefreshToken(refreshToken string, userType com
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (repo *TestAuth) CreateSession(session *models.Session) (uint, error) {
+func (repo *TestAuth) CreateSession(rctx *requests.RequestContext, session *models.Session) (uint, error) {
 	return 1, nil
 }
 
-func (repo *TestAuth) DeleteSession(sessionID uint) error {
+func (repo *TestAuth) DeleteSession(rctx *requests.RequestContext, sessionID uint) error {
 	return nil
 }
 
-func (repo *TestAuth) UpdateSession(id uint, refreshToken string, expiresAt int64) error {
+func (repo *TestAuth) UpdateSession(rctx *requests.RequestContext, id uint, refreshToken string, expiresAt int64) error {
 	return nil
 }

--- a/backend/app/repository/avatar_repository.go
+++ b/backend/app/repository/avatar_repository.go
@@ -18,21 +18,21 @@ func NewAvatar(container *storage.Container) *Avatar {
 	}
 }
 
-func (repo *Avatar) Get(id uint) (*models.Avatar, error) {
+func (repo *Avatar) Get(rctx *requests.RequestContext, id uint) (*models.Avatar, error) {
 	var avatar models.Avatar
-	return &avatar, repo.container.Config.ReadOnlyDB.Where("id = ?", id).First(&avatar).Error
+	return &avatar, repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Where("id = ?", id).First(&avatar).Error
 }
 
-func (repo *Avatar) GetByNameAndType(name string, avatarType commonType.AvatarType) *models.Avatar {
+func (repo *Avatar) GetByNameAndType(rctx *requests.RequestContext, name string, avatarType commonType.AvatarType) *models.Avatar {
 	var avatar models.Avatar
-	repo.container.Config.ReadOnlyDB.Where("name = ? and type = ?", name, avatarType).First(&avatar)
+	repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Where("name = ? and type = ?", name, avatarType).First(&avatar)
 	return &avatar
 }
 
-func (repo *Avatar) AvatarByTypeExists(id uint, avatarType commonType.AvatarType) error {
+func (repo *Avatar) AvatarByTypeExists(rctx *requests.RequestContext, id uint, avatarType commonType.AvatarType) error {
 	var count int64
 
-	err := repo.container.Config.ReadOnlyDB.Model(&models.Avatar{}).
+	err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Model(&models.Avatar{}).
 		Where("id = ? AND type = ?", id, avatarType).Count(&count).Error
 
 	if err != nil {
@@ -44,9 +44,9 @@ func (repo *Avatar) AvatarByTypeExists(id uint, avatarType commonType.AvatarType
 	return nil
 }
 
-func (repo *Avatar) GetAvatarsByType(avatarType commonType.AvatarType) (*[]models.Avatar, error) {
+func (repo *Avatar) GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) (*[]models.Avatar, error) {
 	var response []models.Avatar
-	if err := repo.container.Config.ReadOnlyDB.Model(&models.Avatar{}).Where("type = ?", avatarType).Scan(&response).Error; err != nil {
+	if err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Model(&models.Avatar{}).Where("type = ?", avatarType).Scan(&response).Error; err != nil {
 		return nil, err
 	}
 
@@ -56,12 +56,12 @@ func (repo *Avatar) GetAvatarsByType(avatarType commonType.AvatarType) (*[]model
 	return &response, nil
 }
 
-func (repo *Avatar) Create(avatar models.Avatar) (uint, error) {
-	return avatar.ID, repo.container.Config.ReadWriteDB.Create(&avatar).Error
+func (repo *Avatar) Create(rctx *requests.RequestContext, avatar models.Avatar) (uint, error) {
+	return avatar.ID, repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Create(&avatar).Error
 }
 
-func (repo *Avatar) Update(id uint, payload requests.AvatarRequest) error {
-	result := repo.container.Config.ReadWriteDB.Model(&models.Avatar{}).
+func (repo *Avatar) Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Model(&models.Avatar{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{
 			"name": payload.Name,

--- a/backend/app/repository/avatar_repository_mock.go
+++ b/backend/app/repository/avatar_repository_mock.go
@@ -20,7 +20,7 @@ func NewTestAvatar(container *storage.Container) *TestAvatar {
 	}
 }
 
-func (repo *TestAvatar) Get(id uint) (*models.Avatar, error) {
+func (repo *TestAvatar) Get(rctx *requests.RequestContext, id uint) (*models.Avatar, error) {
 	if id == 1 {
 		return &models.Avatar{
 			BaseModel: models.BaseModel{
@@ -36,7 +36,7 @@ func (repo *TestAvatar) Get(id uint) (*models.Avatar, error) {
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (repo *TestAvatar) GetByNameAndType(name string, avatarType commonType.AvatarType) *models.Avatar {
+func (repo *TestAvatar) GetByNameAndType(rctx *requests.RequestContext, name string, avatarType commonType.AvatarType) *models.Avatar {
 	return &models.Avatar{
 		Name: name,
 		Type: avatarType,
@@ -44,14 +44,14 @@ func (repo *TestAvatar) GetByNameAndType(name string, avatarType commonType.Avat
 	}
 }
 
-func (repo *TestAvatar) AvatarByTypeExists(id uint, avatarType commonType.AvatarType) error {
+func (repo *TestAvatar) AvatarByTypeExists(rctx *requests.RequestContext, id uint, avatarType commonType.AvatarType) error {
 	if id == 1 {
 		return nil
 	}
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestAvatar) GetAvatarsByType(avatarType commonType.AvatarType) (*[]models.Avatar, error) {
+func (repo *TestAvatar) GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) (*[]models.Avatar, error) {
 	responses := []models.Avatar{
 		{
 			BaseModel: models.BaseModel{
@@ -77,11 +77,11 @@ func (repo *TestAvatar) GetAvatarsByType(avatarType commonType.AvatarType) (*[]m
 	return &responses, nil
 }
 
-func (repo *TestAvatar) Create(payload models.Avatar) (uint, error) {
+func (repo *TestAvatar) Create(rctx *requests.RequestContext, payload models.Avatar) (uint, error) {
 	return 1, nil
 }
 
-func (repo *TestAvatar) Update(id uint, payload requests.AvatarRequest) error {
+func (repo *TestAvatar) Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) error {
 	if id != 1 {
 		return gorm.ErrRecordNotFound
 	}

--- a/backend/app/repository/currency_repository.go
+++ b/backend/app/repository/currency_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"github.com/Uttamnath64/arvo-fin/app/models"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
 )
@@ -16,10 +17,10 @@ func NewCurrency(container *storage.Container) *Currency {
 	}
 }
 
-func (repo *Currency) CodeExists(code string) error {
+func (repo *Currency) CodeExists(rctx *requests.RequestContext, code string) error {
 	var count int64
 
-	err := repo.container.Config.ReadOnlyDB.Model(&models.Currency{}).
+	err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Model(&models.Currency{}).
 		Where("code = ?", code).Count(&count).Error
 
 	if err != nil {

--- a/backend/app/repository/currency_repository_mock.go
+++ b/backend/app/repository/currency_repository_mock.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
 )
@@ -15,7 +16,7 @@ func NewTestCurrency(container *storage.Container) *TestCurrency {
 	}
 }
 
-func (repo *TestCurrency) CodeExists(code string) error {
+func (repo *TestCurrency) CodeExists(rctx *requests.RequestContext, code string) error {
 	if code != "INR" {
 		return gorm.ErrRecordNotFound
 	}

--- a/backend/app/repository/portfolio_repository.go
+++ b/backend/app/repository/portfolio_repository.go
@@ -19,10 +19,10 @@ func NewPortfolio(container *storage.Container) *Portfolio {
 	}
 }
 
-func (repo *Portfolio) UserPortfolioExists(id, userId uint) error {
+func (repo *Portfolio) UserPortfolioExists(rctx *requests.RequestContext, id, userId uint) error {
 	var count int64
 
-	err := repo.container.Config.ReadOnlyDB.Model(&models.Portfolio{}).
+	err := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Model(&models.Portfolio{}).
 		Where("id = ? and user_id = ?", id, userId).Count(&count).Error
 
 	if err != nil {
@@ -34,13 +34,13 @@ func (repo *Portfolio) UserPortfolioExists(id, userId uint) error {
 	return nil
 }
 
-func (repo *Portfolio) GetList(userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error) {
+func (repo *Portfolio) GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error) {
 	var portfolio models.Portfolio
 	var avatar models.Avatar
 
 	var portfolios []responses.PortfolioResponse
 
-	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName() + " p").
+	query := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Table(portfolio.GetName() + " p").
 		Joins("JOIN " + avatar.GetName() + " a ON a.id = p.avatar_id")
 	if userType == commonType.UserTypeUser {
 		query = query.Where("p.user_id = ? ", userId)
@@ -57,13 +57,13 @@ func (repo *Portfolio) GetList(userId uint, userType commonType.UserType) (*[]re
 	return &portfolios, nil
 }
 
-func (repo *Portfolio) Get(id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error) {
+func (repo *Portfolio) Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error) {
 	var portfolio models.Portfolio
 	var avatar models.Avatar
 
 	var portfolios responses.PortfolioResponse
 
-	query := repo.container.Config.ReadOnlyDB.Table(portfolio.GetName()+" p").
+	query := repo.container.Config.ReadOnlyDB.WithContext(rctx.Ctx).Table(portfolio.GetName()+" p").
 		Joins("JOIN "+avatar.GetName()+" a ON a.id = p.avatar_id").Where("p.id = ?", id)
 	if userType == commonType.UserTypeUser {
 		query = query.Where("p.user_id = ?", userId)
@@ -80,12 +80,12 @@ func (repo *Portfolio) Get(id, userId uint, userType commonType.UserType) (*resp
 	return &portfolios, nil
 }
 
-func (repo *Portfolio) Create(portfolio models.Portfolio) error {
-	return repo.container.Config.ReadWriteDB.Create(&portfolio).Error
+func (repo *Portfolio) Create(rctx *requests.RequestContext, portfolio models.Portfolio) error {
+	return repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Create(&portfolio).Error
 }
 
-func (repo *Portfolio) Update(id, userId uint, payload requests.PortfolioRequest) error {
-	result := repo.container.Config.ReadWriteDB.Model(&models.Portfolio{}).
+func (repo *Portfolio) Update(rctx *requests.RequestContext, id, userId uint, payload requests.PortfolioRequest) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Model(&models.Portfolio{}).
 		Where("id = ? AND user_id = ?", id, userId).
 		Updates(map[string]interface{}{
 			"name":      payload.Name,
@@ -102,8 +102,8 @@ func (repo *Portfolio) Update(id, userId uint, payload requests.PortfolioRequest
 	return nil
 }
 
-func (repo *Portfolio) Delete(id, userId uint) error {
-	result := repo.container.Config.ReadWriteDB.Where("id = ? AND user_id = ?", id, userId).Delete(&models.Portfolio{})
+func (repo *Portfolio) Delete(rctx *requests.RequestContext, id, userId uint) error {
+	result := repo.container.Config.ReadWriteDB.WithContext(rctx.Ctx).Where("id = ? AND user_id = ?", id, userId).Delete(&models.Portfolio{})
 
 	if result.Error != nil {
 		return result.Error

--- a/backend/app/repository/portfolio_repository_mock.go
+++ b/backend/app/repository/portfolio_repository_mock.go
@@ -19,14 +19,14 @@ func NewTestPortfolio(container *storage.Container) *TestPortfolio {
 	}
 }
 
-func (repo *TestPortfolio) UserPortfolioExists(id, userId uint) error {
+func (repo *TestPortfolio) UserPortfolioExists(rctx *requests.RequestContext, id, userId uint) error {
 	if userId == 1 {
 		return nil
 	}
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestPortfolio) GetList(userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error) {
+func (repo *TestPortfolio) GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error) {
 	if userId == 1 && userType == commonType.UserTypeUser {
 		portfolios := []responses.PortfolioResponse{
 			{
@@ -47,7 +47,7 @@ func (repo *TestPortfolio) GetList(userId uint, userType commonType.UserType) (*
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (repo *TestPortfolio) Get(id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error) {
+func (repo *TestPortfolio) Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error) {
 	if id == 1 && userId == 1 && userType == commonType.UserTypeUser {
 		portfolios := responses.PortfolioResponse{
 			Id:         1,
@@ -60,18 +60,18 @@ func (repo *TestPortfolio) Get(id, userId uint, userType commonType.UserType) (*
 	return nil, gorm.ErrRecordNotFound
 }
 
-func (repo *TestPortfolio) Create(portfolio models.Portfolio) error {
+func (repo *TestPortfolio) Create(rctx *requests.RequestContext, portfolio models.Portfolio) error {
 	return nil
 }
 
-func (repo *TestPortfolio) Update(id, userId uint, payload requests.PortfolioRequest) error {
+func (repo *TestPortfolio) Update(rctx *requests.RequestContext, id, userId uint, payload requests.PortfolioRequest) error {
 	if id == 1 && userId == 1 {
 		return nil
 	}
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestPortfolio) Delete(id, userId uint) error {
+func (repo *TestPortfolio) Delete(rctx *requests.RequestContext, id, userId uint) error {
 	if id == 1 && userId == 1 {
 		return nil
 	}

--- a/backend/app/repository/repository.go
+++ b/backend/app/repository/repository.go
@@ -8,52 +8,52 @@ import (
 )
 
 type AuthRepository interface {
-	GetSessionByUser(userId uint, userType commonType.UserType, signedToken string) (*models.Session, error)
-	GetSessionByRefreshToken(refreshToken string, userType commonType.UserType) (*models.Session, error)
-	CreateSession(session *models.Session) (uint, error)
-	UpdateSession(id uint, refreshToken string, expiresAt int64) error
-	DeleteSession(sessionID uint) error
+	GetSessionByUser(rctx *requests.RequestContext, userId uint, userType commonType.UserType, signedToken string) (*models.Session, error)
+	GetSessionByRefreshToken(rctx *requests.RequestContext, refreshToken string, userType commonType.UserType) (*models.Session, error)
+	CreateSession(rctx *requests.RequestContext, session *models.Session) (uint, error)
+	UpdateSession(rctx *requests.RequestContext, id uint, refreshToken string, expiresAt int64) error
+	DeleteSession(rctx *requests.RequestContext, sessionID uint) error
 }
 
 type AvatarRepository interface {
-	Get(id uint) (*models.Avatar, error)
-	GetByNameAndType(name string, avatarType commonType.AvatarType) *models.Avatar
-	AvatarByTypeExists(id uint, avatarType commonType.AvatarType) error
-	GetAvatarsByType(avatarType commonType.AvatarType) (*[]models.Avatar, error)
-	Create(payload models.Avatar) (uint, error)
-	Update(id uint, payload requests.AvatarRequest) error
+	Get(rctx *requests.RequestContext, id uint) (*models.Avatar, error)
+	GetByNameAndType(rctx *requests.RequestContext, name string, avatarType commonType.AvatarType) *models.Avatar
+	AvatarByTypeExists(rctx *requests.RequestContext, id uint, avatarType commonType.AvatarType) error
+	GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) (*[]models.Avatar, error)
+	Create(rctx *requests.RequestContext, payload models.Avatar) (uint, error)
+	Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) error
 }
 
 type PortfolioRepository interface {
-	UserPortfolioExists(id, userId uint) error
-	GetList(userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error)
-	Get(id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error)
-	Create(portfolio models.Portfolio) error
-	Update(id, userId uint, payload requests.PortfolioRequest) error
-	Delete(id, userId uint) error
+	UserPortfolioExists(rctx *requests.RequestContext, id, userId uint) error
+	GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) (*[]responses.PortfolioResponse, error)
+	Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) (*responses.PortfolioResponse, error)
+	Create(rctx *requests.RequestContext, portfolio models.Portfolio) error
+	Update(rctx *requests.RequestContext, id, userId uint, payload requests.PortfolioRequest) error
+	Delete(rctx *requests.RequestContext, id, userId uint) error
 }
 
 type UserRepository interface {
-	GetUserByUsernameOrEmail(username string, email string, user *models.User) error
-	UsernameExists(username string) error
-	EmailExists(email string) error
-	CreateUser(user *models.User) (uint, error)
-	UpdatePasswordByEmail(email, newPassword string) error
-	GetUser(userId uint, user *models.User) error
-	Get(userId uint) (*responses.MeResponse, error)
-	GetSettings(userId uint) (*responses.SettingsResponse, error)
-	Update(userId uint, payload requests.MeRequest) error
-	UpdateSettings(userId uint, payload requests.SettingsRequest) error
+	GetUserByUsernameOrEmail(rctx *requests.RequestContext, username string, email string, user *models.User) error
+	UsernameExists(rctx *requests.RequestContext, username string) error
+	EmailExists(rctx *requests.RequestContext, email string) error
+	CreateUser(rctx *requests.RequestContext, user *models.User) (uint, error)
+	UpdatePasswordByEmail(rctx *requests.RequestContext, email, newPassword string) error
+	GetUser(rctx *requests.RequestContext, userId uint, user *models.User) error
+	Get(rctx *requests.RequestContext, userId uint) (*responses.MeResponse, error)
+	GetSettings(rctx *requests.RequestContext, userId uint) (*responses.SettingsResponse, error)
+	Update(rctx *requests.RequestContext, userId uint, payload requests.MeRequest) error
+	UpdateSettings(rctx *requests.RequestContext, userId uint, payload requests.SettingsRequest) error
 }
 
 type CurrencyRepository interface {
-	CodeExists(code string) error
+	CodeExists(rctx *requests.RequestContext, code string) error
 }
 
 type AccountRepository interface {
-	GetList(portfolioId, userId uint) (*[]models.Account, error)
-	Get(id uint) (*models.Account, error)
-	Create(account models.Account) (uint, error)
-	Update(id, userId uint, payload requests.AccountUpdateRequest) error
-	Delete(id, userId uint) error
+	GetList(rctx *requests.RequestContext, portfolioId, userId uint) (*[]models.Account, error)
+	Get(rctx *requests.RequestContext, id uint) (*models.Account, error)
+	Create(rctx *requests.RequestContext, account models.Account) (uint, error)
+	Update(rctx *requests.RequestContext, id, userId uint, payload requests.AccountUpdateRequest) error
+	Delete(rctx *requests.RequestContext, id, userId uint) error
 }

--- a/backend/app/repository/user_repository_mock.go
+++ b/backend/app/repository/user_repository_mock.go
@@ -20,7 +20,7 @@ func NewTestUser(container *storage.Container) *TestUser {
 	}
 }
 
-func (repo *TestUser) GetUserByUsernameOrEmail(username string, email string, user *models.User) error {
+func (repo *TestUser) GetUserByUsernameOrEmail(rctx *requests.RequestContext, username string, email string, user *models.User) error {
 	if username == "uttam.nath" || email == "uttam@example.com" {
 		now := time.Now()
 		*user = models.User{
@@ -39,29 +39,29 @@ func (repo *TestUser) GetUserByUsernameOrEmail(username string, email string, us
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestUser) UsernameExists(username string) error {
+func (repo *TestUser) UsernameExists(rctx *requests.RequestContext, username string) error {
 	if username == "uttam.nath" {
 		return nil
 	}
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestUser) EmailExists(email string) error {
+func (repo *TestUser) EmailExists(rctx *requests.RequestContext, email string) error {
 	if email == "uttam@example.com" {
 		return nil
 	}
 	return gorm.ErrRecordNotFound
 }
 
-func (repo *TestUser) CreateUser(user *models.User) (uint, error) {
+func (repo *TestUser) CreateUser(rctx *requests.RequestContext, user *models.User) (uint, error) {
 	return 1, nil
 }
 
-func (repo *TestUser) UpdatePasswordByEmail(email, newPassword string) error {
+func (repo *TestUser) UpdatePasswordByEmail(rctx *requests.RequestContext, email, newPassword string) error {
 	return nil
 }
 
-func (repo *TestUser) GetUser(userId uint, user *models.User) error {
+func (repo *TestUser) GetUser(rctx *requests.RequestContext, userId uint, user *models.User) error {
 	now := time.Now()
 	*user = models.User{
 		BaseModel: models.BaseModel{
@@ -77,7 +77,7 @@ func (repo *TestUser) GetUser(userId uint, user *models.User) error {
 	return nil
 }
 
-func (repo *TestUser) Get(userId uint) (*responses.MeResponse, error) {
+func (repo *TestUser) Get(rctx *requests.RequestContext, userId uint) (*responses.MeResponse, error) {
 	if userId != 1 {
 		return nil, gorm.ErrRecordNotFound
 	}
@@ -89,7 +89,7 @@ func (repo *TestUser) Get(userId uint) (*responses.MeResponse, error) {
 	}, nil
 }
 
-func (repo *TestUser) GetSettings(userId uint) (*responses.SettingsResponse, error) {
+func (repo *TestUser) GetSettings(rctx *requests.RequestContext, userId uint) (*responses.SettingsResponse, error) {
 	if userId != 1 {
 		return nil, gorm.ErrRecordNotFound
 	}
@@ -104,14 +104,14 @@ func (repo *TestUser) GetSettings(userId uint) (*responses.SettingsResponse, err
 	}, nil
 }
 
-func (repo *TestUser) Update(userId uint, payload requests.MeRequest) error {
+func (repo *TestUser) Update(rctx *requests.RequestContext, userId uint, payload requests.MeRequest) error {
 	if userId != 1 {
 		return gorm.ErrRecordNotFound
 	}
 	return nil
 }
 
-func (repo *TestUser) UpdateSettings(userId uint, payload requests.SettingsRequest) error {
+func (repo *TestUser) UpdateSettings(rctx *requests.RequestContext, userId uint, payload requests.SettingsRequest) error {
 	if userId != 1 {
 		return gorm.ErrRecordNotFound
 	}

--- a/backend/app/requests/context_request.go
+++ b/backend/app/requests/context_request.go
@@ -1,0 +1,14 @@
+package requests
+
+import (
+	"context"
+
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
+)
+
+type RequestContext struct {
+	Ctx       context.Context
+	UserID    uint
+	UserType  commonType.UserType
+	SessionID uint
+}

--- a/backend/app/services/avatar_service.go
+++ b/backend/app/services/avatar_service.go
@@ -23,9 +23,9 @@ func NewAvatar(container *storage.Container) *Avatar {
 	}
 }
 
-func (service *Avatar) Get(id uint) responses.ServiceResponse {
+func (service *Avatar) Get(rctx *requests.RequestContext, id uint) responses.ServiceResponse {
 
-	response, err := service.repoAvatar.Get(id)
+	response, err := service.repoAvatar.Get(rctx, id)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatar not found!", err)
@@ -39,14 +39,14 @@ func (service *Avatar) Get(id uint) responses.ServiceResponse {
 	return responses.SuccessResponse("Avatar records found!", response)
 }
 
-func (service *Avatar) GetAvatarsByType(avatarType commonType.AvatarType) responses.ServiceResponse {
-	response, err := service.repoAvatar.GetAvatarsByType(avatarType)
+func (service *Avatar) GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) responses.ServiceResponse {
+	response, err := service.repoAvatar.GetAvatarsByType(rctx, avatarType)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatars not found by type!", err)
 		}
 
-		service.container.Logger.Error("avatar.appService.getAvatarsByType-GetAvatarsByType", "error", err.Error(), "avatarType", avatarType, "avatarTypeName", avatarType.String())
+		service.container.Logger.Error("avatar.appService.getAvatarsByType-GetAvatarsByType", "error", err.Error(), "avatarType", avatarType)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later.", err)
 	}
 
@@ -54,9 +54,9 @@ func (service *Avatar) GetAvatarsByType(avatarType commonType.AvatarType) respon
 	return responses.SuccessResponse("Avatars found by type!", response)
 }
 
-func (service *Avatar) Creatre(payload requests.AvatarRequest) responses.ServiceResponse {
+func (service *Avatar) Creatre(rctx *requests.RequestContext, payload requests.AvatarRequest) responses.ServiceResponse {
 
-	avatarId, err := service.repoAvatar.Create(models.Avatar{
+	avatarId, err := service.repoAvatar.Create(rctx, models.Avatar{
 		Name: payload.Name,
 		Type: payload.Type,
 		Icon: payload.Icon,
@@ -71,13 +71,13 @@ func (service *Avatar) Creatre(payload requests.AvatarRequest) responses.Service
 	}
 
 	// Response
-	response, _ := service.repoAvatar.Get(avatarId)
+	response, _ := service.repoAvatar.Get(rctx, avatarId)
 	return responses.SuccessResponse("Avatar is created!", response)
 }
 
-func (service *Avatar) Update(id uint, payload requests.AvatarRequest) responses.ServiceResponse {
+func (service *Avatar) Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) responses.ServiceResponse {
 
-	err := service.repoAvatar.Update(id, payload)
+	err := service.repoAvatar.Update(rctx, id, payload)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatar not found!", err)
@@ -88,6 +88,6 @@ func (service *Avatar) Update(id uint, payload requests.AvatarRequest) responses
 	}
 
 	// Response
-	response, _ := service.repoAvatar.Get(id)
+	response, _ := service.repoAvatar.Get(rctx, id)
 	return responses.SuccessResponse("Avatar is updated!", response)
 }

--- a/backend/app/services/portfolio_service.go
+++ b/backend/app/services/portfolio_service.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Uttamnath64/arvo-fin/app/common"
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
 	"github.com/Uttamnath64/arvo-fin/app/repository"
+	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/Uttamnath64/arvo-fin/app/storage"
 	"gorm.io/gorm"
@@ -23,15 +24,15 @@ func NewPortfolio(container *storage.Container) *Portfolio {
 	}
 }
 
-func (service *Portfolio) GetList(userId uint, userType commonType.UserType) responses.ServiceResponse {
+func (service *Portfolio) GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) responses.ServiceResponse {
 
-	response, err := service.portfolioRepo.GetList(userId, userType)
+	response, err := service.portfolioRepo.GetList(rctx, userId, userType)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Portfolios not found!", err)
 		}
 
-		service.container.Logger.Error("portfolio.appService.getList-GetList", "error", err.Error(), "userId", userId, "userType", userType, "userTypeName", userType.String())
+		service.container.Logger.Error("portfolio.appService.getList-GetList", "error", err.Error(), "userId", userId, "userType", userType)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later.", err)
 	}
 
@@ -39,15 +40,15 @@ func (service *Portfolio) GetList(userId uint, userType commonType.UserType) res
 	return responses.SuccessResponse("Portfolios records found!", response)
 }
 
-func (service *Portfolio) Get(id, userId uint, userType commonType.UserType) responses.ServiceResponse {
+func (service *Portfolio) Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) responses.ServiceResponse {
 
-	response, err := service.portfolioRepo.Get(id, userId, userType)
+	response, err := service.portfolioRepo.Get(rctx, id, userId, userType)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Portfolio not found!", err)
 		}
 
-		service.container.Logger.Error("portfolio.appService.get-Get", "error", err.Error(), "id", id, "userId", userId, "userType", userType, "userTypeName", userType.String())
+		service.container.Logger.Error("portfolio.appService.get-Get", "error", err.Error(), "id", id, "userId", userId, "userType", userType)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later.", err)
 	}
 

--- a/backend/app/services/service.go
+++ b/backend/app/services/service.go
@@ -22,29 +22,29 @@ type OTPService interface {
 }
 
 type PortfolioService interface {
-	GetList(userId uint, userType commonType.UserType) responses.ServiceResponse
-	Get(id, userId uint, userType commonType.UserType) responses.ServiceResponse
+	GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) responses.ServiceResponse
+	Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) responses.ServiceResponse
 }
 
 type UserService interface {
-	Get(userId uint) responses.ServiceResponse
-	GetSettings(userId uint) responses.ServiceResponse
-	Update(payload requests.MeRequest, userId uint) responses.ServiceResponse
-	UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse
+	Get(rctx *requests.RequestContext, userId uint) responses.ServiceResponse
+	GetSettings(rctx *requests.RequestContext, userId uint) responses.ServiceResponse
+	Update(rctx *requests.RequestContext, payload requests.MeRequest, userId uint) responses.ServiceResponse
+	UpdateSettings(rctx *requests.RequestContext, payload requests.SettingsRequest, userId uint) responses.ServiceResponse
 }
 
 type AvatarService interface {
-	Get(id uint) responses.ServiceResponse
-	GetAvatarsByType(avatarType commonType.AvatarType) responses.ServiceResponse
-	Creatre(payload requests.AvatarRequest) responses.ServiceResponse
-	Update(id uint, payload requests.AvatarRequest) responses.ServiceResponse
+	Get(rctx *requests.RequestContext, id uint) responses.ServiceResponse
+	GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) responses.ServiceResponse
+	Creatre(rctx *requests.RequestContext, payload requests.AvatarRequest) responses.ServiceResponse
+	Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) responses.ServiceResponse
 }
 
 type AccountService interface {
-	Get(id uint) responses.ServiceResponse
-	GetList(portfolioId, userId uint) responses.ServiceResponse
-	AccountTypes() responses.ServiceResponse
-	Create(userId uint, payload requests.AccountRequest) responses.ServiceResponse
-	Update(id, userId uint, payload requests.AccountUpdateRequest) responses.ServiceResponse
-	Delete(id, userId uint) responses.ServiceResponse
+	Get(rctx *requests.RequestContext, id uint) responses.ServiceResponse
+	GetList(rctx *requests.RequestContext, portfolioId, userId uint) responses.ServiceResponse
+	AccountTypes(rctx *requests.RequestContext) responses.ServiceResponse
+	Create(rctx *requests.RequestContext, userId uint, payload requests.AccountRequest) responses.ServiceResponse
+	Update(rctx *requests.RequestContext, id, userId uint, payload requests.AccountUpdateRequest) responses.ServiceResponse
+	Delete(rctx *requests.RequestContext, id, userId uint) responses.ServiceResponse
 }

--- a/backend/app/services/user_service.go
+++ b/backend/app/services/user_service.go
@@ -28,9 +28,9 @@ func NewUser(container *storage.Container) *User {
 	}
 }
 
-func (service *User) Get(userId uint) responses.ServiceResponse {
+func (service *User) Get(rctx *requests.RequestContext, userId uint) responses.ServiceResponse {
 
-	response, err := service.repoUser.Get(userId)
+	response, err := service.repoUser.Get(rctx, userId)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "User not found!", err)
@@ -43,8 +43,8 @@ func (service *User) Get(userId uint) responses.ServiceResponse {
 	return responses.SuccessResponse("User records found!", response)
 }
 
-func (service *User) GetSettings(userId uint) responses.ServiceResponse {
-	response, err := service.repoUser.GetSettings(userId)
+func (service *User) GetSettings(rctx *requests.RequestContext, userId uint) responses.ServiceResponse {
+	response, err := service.repoUser.GetSettings(rctx, userId)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "User not found!", err)
@@ -58,19 +58,19 @@ func (service *User) GetSettings(userId uint) responses.ServiceResponse {
 	return responses.SuccessResponse("User settings found!", response)
 }
 
-func (service *User) Update(payload requests.MeRequest, userId uint) responses.ServiceResponse {
+func (service *User) Update(rctx *requests.RequestContext, payload requests.MeRequest, userId uint) responses.ServiceResponse {
 
 	// Check avatar
-	if err := service.repoAvatar.AvatarByTypeExists(payload.AvatarId, commonType.AvatarTypeUser); err != nil {
+	if err := service.repoAvatar.AvatarByTypeExists(rctx, payload.AvatarId, commonType.AvatarTypeUser); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatar not found!", errors.New("avatar not found"))
 		}
-		service.container.Logger.Error("user.appService.update-GetSettings", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypeUser, "avatarTypeName", commonType.AvatarTypeUser.String())
+		service.container.Logger.Error("user.appService.update-GetSettings", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypeUser)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later.", err)
 	}
 
 	// update
-	if err := service.repoUser.Update(userId, payload); err != nil {
+	if err := service.repoUser.Update(rctx, userId, payload); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "User not found!", err)
 		}
@@ -83,10 +83,10 @@ func (service *User) Update(payload requests.MeRequest, userId uint) responses.S
 	return responses.SuccessResponse("User records updated!", nil)
 }
 
-func (service *User) UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
+func (service *User) UpdateSettings(rctx *requests.RequestContext, payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
 
 	// Check currencyCode
-	if err := service.repoCurrency.CodeExists(payload.CurrencyCode); err != nil {
+	if err := service.repoCurrency.CodeExists(rctx, payload.CurrencyCode); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Currency not found!", err)
 		}
@@ -96,7 +96,7 @@ func (service *User) UpdateSettings(payload requests.SettingsRequest, userId uin
 	}
 
 	// Update
-	if err := service.repoUser.UpdateSettings(userId, payload); err != nil {
+	if err := service.repoUser.UpdateSettings(rctx, userId, payload); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "User not found!", err)
 		}

--- a/backend/app/storage/container.go
+++ b/backend/app/storage/container.go
@@ -1,14 +1,11 @@
 package storage
 
 import (
-	"context"
-
 	"github.com/Uttamnath64/arvo-fin/app/config"
 	"github.com/Uttamnath64/arvo-fin/pkg/logger"
 )
 
 type Container struct {
-	Ctx    context.Context
 	Config *config.Config
 	Logger *logger.Logger
 	Redis  *RedisClient
@@ -16,9 +13,8 @@ type Container struct {
 }
 
 // NewContainer initializes the DI container
-func NewContainer(ctx context.Context, cfg *config.Config, log *logger.Logger, redis *RedisClient, env *config.AppEnv) *Container {
+func NewContainer(cfg *config.Config, log *logger.Logger, redis *RedisClient, env *config.AppEnv) *Container {
 	return &Container{
-		Ctx:    ctx,
 		Config: cfg,
 		Logger: log,
 		Redis:  redis,

--- a/backend/fin-api/application/application.go
+++ b/backend/fin-api/application/application.go
@@ -75,7 +75,7 @@ func (a *Application) Initialize() bool {
 		return false
 	}
 
-	a.container = storage.NewContainer(ctx, &con, log, redis, &env)
+	a.container = storage.NewContainer(&con, log, redis, &env)
 
 	return true
 

--- a/backend/fin-api/internal/handlers/auth_handler.go
+++ b/backend/fin-api/internal/handlers/auth_handler.go
@@ -22,100 +22,125 @@ func NewAuth(container *storage.Container) *Auth {
 	}
 }
 
-func (handler *Auth) Login(ctx *gin.Context) {
+func (handler *Auth) Login(c *gin.Context) {
+
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
 
 	var payload requests.LoginRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	if !bindAndValidateJson(c, &payload) {
 		return
 	}
 
-	serviceResponse := handler.authService.Login(payload, ctx.Request.UserAgent(), ctx.ClientIP())
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.authService.Login(rctx, payload, c.Request.UserAgent(), c.ClientIP())
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	authR, _ := serviceResponse.Data.(responses.AuthResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: authR,
 	})
 }
 
-func (handler *Auth) Register(ctx *gin.Context) {
+func (handler *Auth) Register(c *gin.Context) {
+
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
 
 	var payload requests.RegisterRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	if !bindAndValidateJson(c, &payload) {
 		return
 	}
 
-	serviceResponse := handler.authService.Register(payload, ctx.Request.UserAgent(), ctx.ClientIP())
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.authService.Register(rctx, payload, c.Request.UserAgent(), c.ClientIP())
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	authR, _ := serviceResponse.Data.(responses.AuthResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: authR,
 	})
 }
 
-func (handler *Auth) SendOTP(ctx *gin.Context) {
+func (handler *Auth) SendOTP(c *gin.Context) {
+
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
 
 	var payload requests.SentOTPRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	if !bindAndValidateJson(c, &payload) {
 		return
 	}
 
-	serviceResponse := handler.authService.SendOTP(payload)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.authService.SendOTP(rctx, payload)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:  true,
 		Message: "OTP sent successfully to the email address!",
 	})
 }
 
-func (handler *Auth) ResetPassword(ctx *gin.Context) {
+func (handler *Auth) ResetPassword(c *gin.Context) {
+
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
 
 	var payload requests.ResetPasswordRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	if !bindAndValidateJson(c, &payload) {
 		return
 	}
 
 	// Reset password
-	serviceResponse := handler.authService.ResetPassword(payload, ctx.Request.UserAgent(), ctx.ClientIP())
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.authService.ResetPassword(rctx, payload, c.Request.UserAgent(), c.ClientIP())
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	authR, _ := serviceResponse.Data.(responses.AuthResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: authR,
 	})
 }
 
-func (handler *Auth) Token(ctx *gin.Context) {
+func (handler *Auth) Token(c *gin.Context) {
+
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
 
 	var payload requests.TokenRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	if !bindAndValidateJson(c, &payload) {
 		return
 	}
 
 	// Get token
-	serviceResponse := handler.authService.GetToken(payload, ctx.Request.UserAgent(), ctx.ClientIP())
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.authService.GetToken(rctx, payload, c.Request.UserAgent(), c.ClientIP())
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	authR, _ := serviceResponse.Data.(responses.AuthResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: authR,

--- a/backend/fin-api/internal/handlers/avatar_handler.go
+++ b/backend/fin-api/internal/handlers/avatar_handler.go
@@ -24,34 +24,44 @@ func NewAvatar(container *storage.Container) *Avatar {
 	}
 }
 
-func (handler *Avatar) Get(ctx *gin.Context) {
+func (handler *Avatar) Get(c *gin.Context) {
 
-	id, err := strconv.Atoi(ctx.Param("id"))
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil || id <= 0 {
-		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+		c.JSON(http.StatusBadRequest, responses.ApiResponse{
 			Status:  false,
 			Message: "Invalid avatar id!",
 		})
 		return
 	}
 
-	serviceResponse := handler.avatarService.Get(uint(id))
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.avatarService.Get(rctx, uint(id))
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: serviceResponse.Data,
 	})
 }
 
-func (handler *Avatar) GetAvatarsByType(ctx *gin.Context) {
+func (handler *Avatar) GetAvatarsByType(c *gin.Context) {
 
-	typeInt, err := strconv.Atoi(ctx.Param("type"))
+	rctx, ok := getRequestContext(c)
+	if !ok {
+		return
+	}
+
+	typeInt, err := strconv.Atoi(c.Param("type"))
 	if err != nil || typeInt <= 0 {
-		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+		c.JSON(http.StatusBadRequest, responses.ApiResponse{
 			Status:  false,
 			Message: "Invalid type!",
 		})
@@ -60,91 +70,91 @@ func (handler *Avatar) GetAvatarsByType(ctx *gin.Context) {
 
 	avatarType := commonType.AvatarType(typeInt)
 	if !avatarType.IsValid() {
-		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+		c.JSON(http.StatusBadRequest, responses.ApiResponse{
 			Status:  false,
 			Message: "Invalid avatar type!",
 		})
 		return
 	}
 
-	serviceResponse := handler.avatarService.GetAvatarsByType(avatarType)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.avatarService.GetAvatarsByType(rctx, avatarType)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: serviceResponse.Data,
 	})
 }
 
-func (handler *Avatar) Create(ctx *gin.Context) {
+func (handler *Avatar) Create(c *gin.Context) {
 
-	var payload requests.AvatarRequest
-	if !bindAndValidateJson(ctx, &payload) {
-		return
-	}
-
-	userInfo, ok := getUserInfo(ctx)
+	rctx, ok := getRequestContext(c)
 	if !ok {
 		return
 	}
 
-	if userInfo.userType != commonType.UserTypeAdmin {
-		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+	var payload requests.AvatarRequest
+	if !bindAndValidateJson(c, &payload) {
+		return
+	}
+
+	if rctx.UserType != commonType.UserTypeAdmin {
+		c.JSON(http.StatusForbidden, responses.ApiResponse{
 			Status:  false,
 			Message: "Only admin can add avatar!",
 		})
 		return
 	}
 
-	serviceResponse := handler.avatarService.Create(payload)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.avatarService.Create(rctx, payload)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:  true,
 		Message: serviceResponse.Message,
 	})
 }
 
-func (handler *Avatar) Update(ctx *gin.Context) {
+func (handler *Avatar) Update(c *gin.Context) {
 
-	var payload requests.AvatarRequest
-	if !bindAndValidateJson(ctx, &payload) {
+	rctx, ok := getRequestContext(c)
+	if !ok {
 		return
 	}
 
-	id, err := strconv.Atoi(ctx.Param("id"))
+	var payload requests.AvatarRequest
+	if !bindAndValidateJson(c, &payload) {
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil || id <= 0 {
-		ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+		c.JSON(http.StatusBadRequest, responses.ApiResponse{
 			Status:  false,
 			Message: "Invalid avatar id!",
 		})
 		return
 	}
 
-	userInfo, ok := getUserInfo(ctx)
-	if !ok {
-		return
-	}
-
-	if userInfo.userType != commonType.UserTypeAdmin {
-		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+	if rctx.UserType != commonType.UserTypeAdmin {
+		c.JSON(http.StatusForbidden, responses.ApiResponse{
 			Status:  false,
 			Message: "Only admin can update avatar!",
 		})
 		return
 	}
 
-	serviceResponse := handler.avatarService.Update(uint(id), payload)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.avatarService.Update(rctx, uint(id), payload)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:  true,
 		Message: serviceResponse.Message,
 	})

--- a/backend/fin-api/internal/handlers/handler_test.go
+++ b/backend/fin-api/internal/handlers/handler_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/Uttamnath64/arvo-fin/app/common"
-	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
 	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/responses"
 	"github.com/gin-gonic/gin"
@@ -168,61 +167,6 @@ func TestBindAndValidateJson(t *testing.T) {
 			default:
 				t.Fatalf("unsupported type for test: %T", tt.body)
 			}
-		})
-	}
-}
-
-func TestGetUserInfo(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	tests := []struct {
-		name       string
-		userId     interface{}
-		userType   interface{}
-		exUserId   uint
-		exUserType commonType.UserType
-		isValid    bool
-	}{
-		{
-			name:       "Invalid UserId",
-			userId:     -1,
-			userType:   1,
-			exUserId:   uint(0),
-			exUserType: commonType.UserTypeUser,
-			isValid:    false,
-		},
-		{
-			name:       "Invalid UserType",
-			userId:     uint(10),
-			userType:   10,
-			exUserId:   uint(10),
-			exUserType: commonType.UserTypeAdmin,
-			isValid:    false,
-		},
-		{
-			name:       "Valid User",
-			userId:     uint(10),
-			userType:   1,
-			exUserId:   uint(10),
-			exUserType: commonType.UserTypeUser,
-			isValid:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			w := httptest.NewRecorder()
-			ctx, _ := gin.CreateTestContext(w)
-			ctx.Set("user_id", tt.userId)
-			ctx.Set("user_type", tt.userType)
-
-			user, ok := getUserInfo(ctx)
-			assert.Equal(t, tt.isValid, ok && user.userType.IsValid())
-			if tt.isValid {
-				assert.Equal(t, tt.exUserId, user.userId)
-				assert.Equal(t, tt.exUserType, user.userType)
-			}
-
 		})
 	}
 }

--- a/backend/fin-api/internal/handlers/me_handler.go
+++ b/backend/fin-api/internal/handlers/me_handler.go
@@ -24,19 +24,19 @@ func NewMe(container *storage.Container) *Me {
 	}
 }
 
-func (handler *Me) Get(ctx *gin.Context) {
+func (handler *Me) Get(c *gin.Context) {
 
-	userInfo, ok := getUserInfo(ctx)
+	rctx, ok := getRequestContext(c)
 	if !ok {
 		return
 	}
-	userId := userInfo.userId
+	userId := rctx.UserID
 
 	// User is admin then
-	if userInfo.userType == commonType.UserTypeAdmin {
-		id, err := strconv.Atoi(ctx.Param("userId"))
+	if rctx.UserType == commonType.UserTypeAdmin {
+		id, err := strconv.Atoi(c.Param("userId"))
 		if err != nil || id <= 0 {
-			ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			c.JSON(http.StatusBadRequest, responses.ApiResponse{
 				Status:  false,
 				Message: "Invalid user id!",
 			})
@@ -45,32 +45,32 @@ func (handler *Me) Get(ctx *gin.Context) {
 		userId = uint(id)
 	}
 
-	serviceResponse := handler.userService.Get(userId)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.userService.Get(rctx, userId)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	response, _ := serviceResponse.Data.(*responses.MeResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: response,
 	})
 }
 
-func (handler *Me) GetSettings(ctx *gin.Context) {
+func (handler *Me) GetSettings(c *gin.Context) {
 
-	userInfo, ok := getUserInfo(ctx)
+	rctx, ok := getRequestContext(c)
 	if !ok {
 		return
 	}
-	userId := userInfo.userId
+	userId := rctx.UserID
 
 	// User is admin then
-	if userInfo.userType == commonType.UserTypeAdmin {
-		id, err := strconv.Atoi(ctx.Param("userId"))
+	if rctx.UserType == commonType.UserTypeAdmin {
+		id, err := strconv.Atoi(c.Param("userId"))
 		if err != nil || id <= 0 {
-			ctx.JSON(http.StatusBadRequest, responses.ApiResponse{
+			c.JSON(http.StatusBadRequest, responses.ApiResponse{
 				Status:  false,
 				Message: "Invalid user id!",
 			})
@@ -79,74 +79,74 @@ func (handler *Me) GetSettings(ctx *gin.Context) {
 		userId = uint(id)
 	}
 
-	serviceResponse := handler.userService.GetSettings(userId)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.userService.GetSettings(rctx, userId)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
 	response, _ := serviceResponse.Data.(*responses.SettingsResponse)
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:   true,
 		Message:  serviceResponse.Message,
 		Metadata: response,
 	})
 }
 
-func (handler *Me) Update(ctx *gin.Context) {
+func (handler *Me) Update(c *gin.Context) {
 
-	var payload requests.MeRequest
-	if !bindAndValidateJson(ctx, &payload) {
-		return
-	}
-
-	userInfo, ok := getUserInfo(ctx)
+	rctx, ok := getRequestContext(c)
 	if !ok {
 		return
 	}
 
-	if userInfo.userType != commonType.UserTypeUser {
-		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+	var payload requests.MeRequest
+	if !bindAndValidateJson(c, &payload) {
+		return
+	}
+
+	if rctx.UserType != commonType.UserTypeUser {
+		c.JSON(http.StatusForbidden, responses.ApiResponse{
 			Status:  false,
 			Message: "Only users can update profile!",
 		})
 	}
 
-	serviceResponse := handler.userService.Update(payload, userInfo.userId)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.userService.Update(rctx, payload, rctx.UserID)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:  true,
 		Message: serviceResponse.Message,
 	})
 }
 
-func (handler *Me) UpdateSettings(ctx *gin.Context) {
+func (handler *Me) UpdateSettings(c *gin.Context) {
 
-	var payload requests.SettingsRequest
-	if !bindAndValidateJson(ctx, &payload) {
-		return
-	}
-
-	userInfo, ok := getUserInfo(ctx)
+	rctx, ok := getRequestContext(c)
 	if !ok {
 		return
 	}
 
-	if userInfo.userType != commonType.UserTypeUser {
-		ctx.JSON(http.StatusForbidden, responses.ApiResponse{
+	var payload requests.SettingsRequest
+	if !bindAndValidateJson(c, &payload) {
+		return
+	}
+
+	if rctx.UserType != commonType.UserTypeUser {
+		c.JSON(http.StatusForbidden, responses.ApiResponse{
 			Status:  false,
 			Message: "Only users can update setting!",
 		})
 	}
 
-	serviceResponse := handler.userService.UpdateSettings(payload, userInfo.userId)
-	if isErrorResponse(ctx, serviceResponse) {
+	serviceResponse := handler.userService.UpdateSettings(rctx, payload, rctx.UserID)
+	if isErrorResponse(c, serviceResponse) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, responses.ApiResponse{
+	c.JSON(http.StatusOK, responses.ApiResponse{
 		Status:  true,
 		Message: serviceResponse.Message,
 	})

--- a/backend/fin-api/internal/middleware/auth_middleware.go
+++ b/backend/fin-api/internal/middleware/auth_middleware.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/Uttamnath64/arvo-fin/app/requests"
+	"github.com/gin-gonic/gin"
+)
+
+func (m *Middleware) AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		// ⏳ Create a context with timeout (e.g., 5 seconds)
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		rctx := &requests.RequestContext{
+			Ctx: ctx,
+		}
+
+		c.Set("rctx", rctx)
+		c.Next()
+	}
+}

--- a/backend/fin-api/internal/routes/auth_route.go
+++ b/backend/fin-api/internal/routes/auth_route.go
@@ -1,10 +1,14 @@
 package routes
 
-import "github.com/Uttamnath64/arvo-fin/fin-api/internal/handlers"
+import (
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/handlers"
+	"github.com/Uttamnath64/arvo-fin/fin-api/internal/middleware"
+)
 
 func (routes *Routes) AuthRoutes() {
 	handler := handlers.NewAuth(routes.container)
-	userGroup := routes.server.Group("/auth")
+	middle := middleware.New(routes.container)
+	userGroup := routes.server.Group("/auth").Use(middle.AuthMiddleware())
 	{
 		userGroup.POST("/login", handler.Login)
 		userGroup.POST("/token", handler.Token)

--- a/backend/fin-api/internal/services/account_service.go
+++ b/backend/fin-api/internal/services/account_service.go
@@ -19,25 +19,25 @@ func NewAccount(container *storage.Container) *Account {
 	}
 }
 
-func (service *Account) Get(id uint) responses.ServiceResponse {
-	return service.accountService.Get(id)
+func (service *Account) Get(rctx *requests.RequestContext, id uint) responses.ServiceResponse {
+	return service.accountService.Get(rctx, id)
 }
-func (service *Account) GetList(portfolioId, userId uint) responses.ServiceResponse {
-	return service.accountService.GetList(portfolioId, userId)
-}
-
-func (service *Account) AccountTypes() responses.ServiceResponse {
-	return service.accountService.AccountTypes()
+func (service *Account) GetList(rctx *requests.RequestContext, portfolioId, userId uint) responses.ServiceResponse {
+	return service.accountService.GetList(rctx, portfolioId, userId)
 }
 
-func (service *Account) Create(userId uint, payload requests.AccountRequest) responses.ServiceResponse {
-	return service.accountService.Create(userId, payload)
+func (service *Account) AccountTypes(rctx *requests.RequestContext) responses.ServiceResponse {
+	return service.accountService.AccountTypes(rctx)
 }
 
-func (service *Account) Update(id, userId uint, payload requests.AccountUpdateRequest) responses.ServiceResponse {
-	return service.accountService.Update(id, userId, payload)
+func (service *Account) Create(rctx *requests.RequestContext, userId uint, payload requests.AccountRequest) responses.ServiceResponse {
+	return service.accountService.Create(rctx, userId, payload)
 }
 
-func (service *Account) Delete(id, userId uint) responses.ServiceResponse {
-	return service.accountService.Delete(id, userId)
+func (service *Account) Update(rctx *requests.RequestContext, id, userId uint, payload requests.AccountUpdateRequest) responses.ServiceResponse {
+	return service.accountService.Update(rctx, id, userId, payload)
+}
+
+func (service *Account) Delete(rctx *requests.RequestContext, id, userId uint) responses.ServiceResponse {
+	return service.accountService.Delete(rctx, id, userId)
 }

--- a/backend/fin-api/internal/services/account_service_test.go
+++ b/backend/fin-api/internal/services/account_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
@@ -9,20 +10,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestAccount() (*Account, bool) {
+func NewTestAccount() (*Account, *requests.RequestContext, bool) {
 	container, ok := getTestContainer()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
 	return &Account{
-		container:      container,
-		accountService: commonServices.NewTestAccount(container),
-	}, true
+			container:      container,
+			accountService: commonServices.NewTestAccount(container),
+		}, &requests.RequestContext{
+			Ctx:       context.Background(),
+			UserID:    1,
+			UserType:  commonType.UserTypeUser,
+			SessionID: 1,
+		}, true
 }
 
 func TestGetList_Account(t *testing.T) {
-	service, ok := NewTestAccount()
+	service, rctx, ok := NewTestAccount()
 	if !ok {
 		return
 	}
@@ -50,14 +56,14 @@ func TestGetList_Account(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.GetList(tt.userId, tt.portfolioId)
+			serviceResponse := service.GetList(rctx, tt.userId, tt.portfolioId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestGet_Account(t *testing.T) {
-	service, ok := NewTestAccount()
+	service, rctx, ok := NewTestAccount()
 	if !ok {
 		return
 	}
@@ -82,14 +88,14 @@ func TestGet_Account(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Get(tt.Id)
+			serviceResponse := service.Get(rctx, tt.Id)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestCreate_Account(t *testing.T) {
-	service, ok := NewTestAccount()
+	service, rctx, ok := NewTestAccount()
 	if !ok {
 		return
 	}
@@ -134,14 +140,14 @@ func TestCreate_Account(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Create(tt.userId, tt.payload)
+			serviceResponse := service.Create(rctx, tt.userId, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestUpdate_Account(t *testing.T) {
-	service, ok := NewTestAccount()
+	service, rctx, ok := NewTestAccount()
 	if !ok {
 		return
 	}
@@ -184,14 +190,14 @@ func TestUpdate_Account(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Update(tt.Id, tt.userId, tt.payload)
+			serviceResponse := service.Update(rctx, tt.Id, tt.userId, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestDelete_Account(t *testing.T) {
-	service, ok := NewTestAccount()
+	service, rctx, ok := NewTestAccount()
 	if !ok {
 		return
 	}
@@ -219,7 +225,7 @@ func TestDelete_Account(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Delete(tt.Id, tt.userId)
+			serviceResponse := service.Delete(rctx, tt.Id, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}

--- a/backend/fin-api/internal/services/auth_service_test.go
+++ b/backend/fin-api/internal/services/auth_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Uttamnath64/arvo-fin/app/auth"
@@ -11,26 +12,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestAuth() (*Auth, bool) {
+func NewTestAuth() (*Auth, *requests.RequestContext, bool) {
 	container, ok := getTestContainer()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
 	authRepo := repository.NewTestAuth(container)
 	return &Auth{
-		container:    container,
-		userRepo:     repository.NewTestUser(container),
-		authRepo:     authRepo,
-		avatarRepo:   repository.NewTestAvatar(container),
-		authHelper:   auth.New(container, authRepo),
-		otpService:   appService.NewTestOTP(container.Redis, 300),
-		emailService: appService.NewTestEmail(container),
-	}, true
+			container:    container,
+			userRepo:     repository.NewTestUser(container),
+			authRepo:     authRepo,
+			avatarRepo:   repository.NewTestAvatar(container),
+			authHelper:   auth.New(container, authRepo),
+			otpService:   appService.NewTestOTP(container.Redis, 300),
+			emailService: appService.NewTestEmail(container),
+		}, &requests.RequestContext{
+			Ctx:       context.Background(),
+			UserID:    1,
+			UserType:  commonType.UserTypeUser,
+			SessionID: 1,
+		}, true
 }
 
 func TestLogin_Auth(t *testing.T) {
-	authService, ok := NewTestAuth()
+	authService, rctx, ok := NewTestAuth()
 	if !ok {
 		return
 	}
@@ -61,14 +67,14 @@ func TestLogin_Auth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := authService.Login(tt.payload, "", "")
+			serviceResponse := authService.Login(rctx, tt.payload, "", "")
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestRegister_Auth(t *testing.T) {
-	authService, ok := NewTestAuth()
+	authService, rctx, ok := NewTestAuth()
 	if !ok {
 		return
 	}
@@ -107,14 +113,14 @@ func TestRegister_Auth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := authService.Register(tt.payload, "", "")
+			serviceResponse := authService.Register(rctx, tt.payload, "", "")
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestSentOTP_Auth(t *testing.T) {
-	authService, ok := NewTestAuth()
+	authService, rctx, ok := NewTestAuth()
 	if !ok {
 		return
 	}
@@ -137,14 +143,14 @@ func TestSentOTP_Auth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := authService.SendOTP(tt.payload)
+			serviceResponse := authService.SendOTP(rctx, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestResetPassword_Auth(t *testing.T) {
-	authService, ok := NewTestAuth()
+	authService, rctx, ok := NewTestAuth()
 	if !ok {
 		return
 	}
@@ -195,14 +201,14 @@ func TestResetPassword_Auth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := authService.ResetPassword(tt.payload, "", "")
+			serviceResponse := authService.ResetPassword(rctx, tt.payload, "", "")
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestGetToken_Auth(t *testing.T) {
-	authService, ok := NewTestAuth()
+	authService, rctx, ok := NewTestAuth()
 	if !ok {
 		return
 	}
@@ -231,7 +237,7 @@ func TestGetToken_Auth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := authService.GetToken(tt.payload, "", "")
+			serviceResponse := authService.GetToken(rctx, tt.payload, "", "")
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}

--- a/backend/fin-api/internal/services/avater_service.go
+++ b/backend/fin-api/internal/services/avater_service.go
@@ -20,18 +20,18 @@ func NewAvatar(container *storage.Container) *Avatar {
 	}
 }
 
-func (service *Avatar) Get(id uint) responses.ServiceResponse {
-	return service.avatarService.Get(id)
+func (service *Avatar) Get(rctx *requests.RequestContext, id uint) responses.ServiceResponse {
+	return service.avatarService.Get(rctx, id)
 }
 
-func (service *Avatar) GetAvatarsByType(avatarType commonType.AvatarType) responses.ServiceResponse {
-	return service.avatarService.GetAvatarsByType(avatarType)
+func (service *Avatar) GetAvatarsByType(rctx *requests.RequestContext, avatarType commonType.AvatarType) responses.ServiceResponse {
+	return service.avatarService.GetAvatarsByType(rctx, avatarType)
 }
 
-func (service *Avatar) Create(payload requests.AvatarRequest) responses.ServiceResponse {
-	return service.avatarService.Creatre(payload)
+func (service *Avatar) Create(rctx *requests.RequestContext, payload requests.AvatarRequest) responses.ServiceResponse {
+	return service.avatarService.Creatre(rctx, payload)
 }
 
-func (service *Avatar) Update(id uint, payload requests.AvatarRequest) responses.ServiceResponse {
-	return service.avatarService.Update(id, payload)
+func (service *Avatar) Update(rctx *requests.RequestContext, id uint, payload requests.AvatarRequest) responses.ServiceResponse {
+	return service.avatarService.Update(rctx, id, payload)
 }

--- a/backend/fin-api/internal/services/avater_service_test.go
+++ b/backend/fin-api/internal/services/avater_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
@@ -9,20 +10,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestAvatar() (*Avatar, bool) {
+func NewTestAvatar() (*Avatar, *requests.RequestContext, bool) {
 	container, ok := getTestContainer()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
 	return &Avatar{
-		container:     container,
-		avatarService: services.NewTestAvatar(container),
-	}, true
+			container:     container,
+			avatarService: services.NewTestAvatar(container),
+		}, &requests.RequestContext{
+			Ctx:       context.Background(),
+			UserID:    1,
+			UserType:  commonType.UserTypeUser,
+			SessionID: 1,
+		}, true
 }
 
 func TestGetAvatarsByType_Avatar(t *testing.T) {
-	service, ok := NewTestAvatar()
+	service, rctx, ok := NewTestAvatar()
 	if !ok {
 		return
 	}
@@ -48,14 +54,14 @@ func TestGetAvatarsByType_Avatar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.GetAvatarsByType(tt.avatarType)
+			serviceResponse := service.GetAvatarsByType(rctx, tt.avatarType)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestGet_Avatar(t *testing.T) {
-	service, ok := NewTestAvatar()
+	service, rctx, ok := NewTestAvatar()
 	if !ok {
 		return
 	}
@@ -80,14 +86,14 @@ func TestGet_Avatar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Get(tt.Id)
+			serviceResponse := service.Get(rctx, tt.Id)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestCreate_Avatar(t *testing.T) {
-	service, ok := NewTestAvatar()
+	service, rctx, ok := NewTestAvatar()
 	if !ok {
 		return
 	}
@@ -120,14 +126,14 @@ func TestCreate_Avatar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Create(tt.payload)
+			serviceResponse := service.Create(rctx, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestUpdate_Avatar(t *testing.T) {
-	service, ok := NewTestAvatar()
+	service, rctx, ok := NewTestAvatar()
 	if !ok {
 		return
 	}
@@ -169,7 +175,7 @@ func TestUpdate_Avatar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := service.Update(tt.Id, tt.payload)
+			serviceResponse := service.Update(rctx, tt.Id, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}

--- a/backend/fin-api/internal/services/portfolio_service.go
+++ b/backend/fin-api/internal/services/portfolio_service.go
@@ -30,15 +30,15 @@ func NewPortfolio(container *storage.Container) *Portfolio {
 	}
 }
 
-func (service *Portfolio) GetList(userId uint, userType commonType.UserType) responses.ServiceResponse {
-	return service.portfolioService.GetList(userId, userType)
+func (service *Portfolio) GetList(rctx *requests.RequestContext, userId uint, userType commonType.UserType) responses.ServiceResponse {
+	return service.portfolioService.GetList(rctx, userId, userType)
 }
 
-func (service *Portfolio) Get(id, userId uint, userType commonType.UserType) responses.ServiceResponse {
-	return service.portfolioService.Get(id, userId, userType)
+func (service *Portfolio) Get(rctx *requests.RequestContext, id, userId uint, userType commonType.UserType) responses.ServiceResponse {
+	return service.portfolioService.Get(rctx, id, userId, userType)
 }
 
-func (service *Portfolio) Create(payload requests.PortfolioRequest, userId uint) responses.ServiceResponse {
+func (service *Portfolio) Create(rctx *requests.RequestContext, payload requests.PortfolioRequest, userId uint) responses.ServiceResponse {
 
 	portfolio := models.Portfolio{
 		Name:     payload.Name,
@@ -47,51 +47,51 @@ func (service *Portfolio) Create(payload requests.PortfolioRequest, userId uint)
 	}
 
 	// Verify avatar
-	if err := service.avatarRepo.AvatarByTypeExists(payload.AvatarId, commonType.AvatarTypePortfolio); err != nil {
+	if err := service.avatarRepo.AvatarByTypeExists(rctx, payload.AvatarId, commonType.AvatarTypePortfolio); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatar not found!", errors.New("avatar not found"))
 		}
 
-		service.container.Logger.Error("portfolio.service.create-AvatarByTypeExists", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypePortfolio, "avatarTypeName", commonType.AvatarTypePortfolio.String())
+		service.container.Logger.Error("portfolio.service.create-AvatarByTypeExists", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypePortfolio)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later", err)
 	}
 
 	// Create
-	if err := service.portfolioRepo.Create(portfolio); err != nil {
+	if err := service.portfolioRepo.Create(rctx, portfolio); err != nil {
 		service.container.Logger.Error("portfolio.service.create-Create", "error", err.Error(), "portfolio", portfolio)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later", err)
 	}
 
 	// Response
-	response, _ := service.portfolioRepo.Get(portfolio.ID, portfolio.UserId, commonType.UserTypeUser)
+	response, _ := service.portfolioRepo.Get(rctx, portfolio.ID, portfolio.UserId, commonType.UserTypeUser)
 	return responses.SuccessResponse("Portfolio record added!", response)
 }
 
-func (service *Portfolio) Update(id, userId uint, payload requests.PortfolioRequest) responses.ServiceResponse {
+func (service *Portfolio) Update(rctx *requests.RequestContext, id, userId uint, payload requests.PortfolioRequest) responses.ServiceResponse {
 
 	// Verify avatar
-	if err := service.avatarRepo.AvatarByTypeExists(payload.AvatarId, commonType.AvatarTypePortfolio); err != nil {
+	if err := service.avatarRepo.AvatarByTypeExists(rctx, payload.AvatarId, commonType.AvatarTypePortfolio); err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return responses.ErrorResponse(common.StatusNotFound, "Avatar not found!", errors.New("avatar not found"))
 		}
 
-		service.container.Logger.Error("portfolio.service.update-AvatarByTypeExists", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypePortfolio, "avatarTypeName", commonType.AvatarTypePortfolio.String())
+		service.container.Logger.Error("portfolio.service.update-AvatarByTypeExists", "error", err.Error(), "avatarId", payload.AvatarId, "avatarType", commonType.AvatarTypePortfolio)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later", err)
 	}
 
-	if err := service.portfolioRepo.Update(id, userId, payload); err != nil {
+	if err := service.portfolioRepo.Update(rctx, id, userId, payload); err != nil {
 		service.container.Logger.Error("portfolio.service.update-Update", "error", err.Error(), "id", id, "userId", userId, "payload", payload)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later", err)
 	}
 
 	// Response
-	response, _ := service.portfolioRepo.Get(id, userId, commonType.UserTypeUser)
+	response, _ := service.portfolioRepo.Get(rctx, id, userId, commonType.UserTypeUser)
 	return responses.SuccessResponse("Portfolio record updated!", response)
 }
 
-func (service *Portfolio) Delete(id, userId uint) responses.ServiceResponse {
+func (service *Portfolio) Delete(rctx *requests.RequestContext, id, userId uint) responses.ServiceResponse {
 
-	if err := service.portfolioRepo.Delete(id, userId); err != nil {
+	if err := service.portfolioRepo.Delete(rctx, id, userId); err != nil {
 		service.container.Logger.Error("portfolio.service.delete-Delete", "error", err.Error(), "id", id, "userId", userId)
 		return responses.ErrorResponse(common.StatusDatabaseError, "Oops! Something went wrong. Please try again later", err)
 	}

--- a/backend/fin-api/internal/services/portfolio_service_test.go
+++ b/backend/fin-api/internal/services/portfolio_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
@@ -10,22 +11,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestPortfolio() (*Portfolio, bool) {
+func NewTestPortfolio() (*Portfolio, *requests.RequestContext, bool) {
 	container, ok := getTestContainer()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 
 	return &Portfolio{
-		container:        container,
-		portfolioService: commonServices.NewTestPortfolio(container),
-		portfolioRepo:    repository.NewTestPortfolio(container),
-		avatarRepo:       repository.NewTestAvatar(container),
-	}, true
+			container:        container,
+			portfolioService: commonServices.NewTestPortfolio(container),
+			portfolioRepo:    repository.NewTestPortfolio(container),
+			avatarRepo:       repository.NewTestAvatar(container),
+		}, &requests.RequestContext{
+			Ctx:       context.Background(),
+			UserID:    1,
+			UserType:  commonType.UserTypeUser,
+			SessionID: 1,
+		}, true
 }
 
 func TestGetList_Portfolio(t *testing.T) {
-	portfolioService, ok := NewTestPortfolio()
+	portfolioService, rctx, ok := NewTestPortfolio()
 	if !ok {
 		return
 	}
@@ -53,14 +59,14 @@ func TestGetList_Portfolio(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := portfolioService.GetList(tt.userId, tt.userType)
+			serviceResponse := portfolioService.GetList(rctx, tt.userId, tt.userType)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestGet_Portfolio(t *testing.T) {
-	portfolioService, ok := NewTestPortfolio()
+	portfolioService, rctx, ok := NewTestPortfolio()
 	if !ok {
 		return
 	}
@@ -91,14 +97,14 @@ func TestGet_Portfolio(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := portfolioService.Get(tt.Id, tt.userId, tt.userType)
+			serviceResponse := portfolioService.Get(rctx, tt.Id, tt.userId, tt.userType)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestCreate_Portfolio(t *testing.T) {
-	portfolioService, ok := NewTestPortfolio()
+	portfolioService, rctx, ok := NewTestPortfolio()
 	if !ok {
 		return
 	}
@@ -133,14 +139,14 @@ func TestCreate_Portfolio(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := portfolioService.Create(tt.payload, tt.userId)
+			serviceResponse := portfolioService.Create(rctx, tt.payload, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestUpdate_Portfolio(t *testing.T) {
-	portfolioService, ok := NewTestPortfolio()
+	portfolioService, rctx, ok := NewTestPortfolio()
 	if !ok {
 		return
 	}
@@ -177,14 +183,14 @@ func TestUpdate_Portfolio(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := portfolioService.Update(tt.Id, tt.userId, tt.payload)
+			serviceResponse := portfolioService.Update(rctx, tt.Id, tt.userId, tt.payload)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestDelete_Portfolio(t *testing.T) {
-	portfolioService, ok := NewTestPortfolio()
+	portfolioService, rctx, ok := NewTestPortfolio()
 	if !ok {
 		return
 	}
@@ -212,7 +218,7 @@ func TestDelete_Portfolio(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := portfolioService.Delete(tt.Id, tt.userId)
+			serviceResponse := portfolioService.Delete(rctx, tt.Id, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}

--- a/backend/fin-api/internal/services/service_test.go
+++ b/backend/fin-api/internal/services/service_test.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"context"
 	"os"
 
 	"github.com/Uttamnath64/arvo-fin/app/config"
@@ -12,8 +11,6 @@ import (
 
 func getTestContainer() (*storage.Container, bool) {
 	var con config.Config
-	var redis *storage.RedisClient
-	ctx := context.Background()
 	requests.NewResponse()
 
 	// load env
@@ -33,5 +30,5 @@ func getTestContainer() (*storage.Container, bool) {
 		return nil, false
 	}
 
-	return storage.NewContainer(ctx, &con, log, redis, &env), true
+	return storage.NewContainer(&con, log, nil, &env), true
 }

--- a/backend/fin-api/internal/services/user_service.go
+++ b/backend/fin-api/internal/services/user_service.go
@@ -19,18 +19,18 @@ func NewUser(container *storage.Container) *User {
 	}
 }
 
-func (service *User) Get(userId uint) responses.ServiceResponse {
-	return service.userService.Get(userId)
+func (service *User) Get(rctx *requests.RequestContext, userId uint) responses.ServiceResponse {
+	return service.userService.Get(rctx, userId)
 }
 
-func (service *User) GetSettings(userId uint) responses.ServiceResponse {
-	return service.userService.GetSettings(userId)
+func (service *User) GetSettings(rctx *requests.RequestContext, userId uint) responses.ServiceResponse {
+	return service.userService.GetSettings(rctx, userId)
 }
 
-func (service *User) Update(payload requests.MeRequest, userId uint) responses.ServiceResponse {
-	return service.userService.Update(payload, userId)
+func (service *User) Update(rctx *requests.RequestContext, payload requests.MeRequest, userId uint) responses.ServiceResponse {
+	return service.userService.Update(rctx, payload, userId)
 }
 
-func (service *User) UpdateSettings(payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
-	return service.userService.UpdateSettings(payload, userId)
+func (service *User) UpdateSettings(rctx *requests.RequestContext, payload requests.SettingsRequest, userId uint) responses.ServiceResponse {
+	return service.userService.UpdateSettings(rctx, payload, userId)
 }

--- a/backend/fin-api/internal/services/user_service_test.go
+++ b/backend/fin-api/internal/services/user_service_test.go
@@ -1,26 +1,33 @@
 package services
 
 import (
+	"context"
 	"testing"
 
+	commonType "github.com/Uttamnath64/arvo-fin/app/common/types"
 	"github.com/Uttamnath64/arvo-fin/app/requests"
 	"github.com/Uttamnath64/arvo-fin/app/services"
 	"github.com/stretchr/testify/assert"
 )
 
-func NewTestUser() (*User, bool) {
+func NewTestUser() (*User, *requests.RequestContext, bool) {
 	container, ok := getTestContainer()
 	if !ok {
-		return nil, false
+		return nil, nil, false
 	}
 	return &User{
-		container:   container,
-		userService: services.NewTestUser(container),
-	}, true
+			container:   container,
+			userService: services.NewTestUser(container),
+		}, &requests.RequestContext{
+			Ctx:       context.Background(),
+			UserID:    1,
+			UserType:  commonType.UserTypeUser,
+			SessionID: 1,
+		}, true
 }
 
 func TestGet_User(t *testing.T) {
-	userService, ok := NewTestUser()
+	userService, rctx, ok := NewTestUser()
 	if !ok {
 		return
 	}
@@ -45,14 +52,14 @@ func TestGet_User(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := userService.Get(tt.userId)
+			serviceResponse := userService.Get(rctx, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestGetSetting_User(t *testing.T) {
-	userService, ok := NewTestUser()
+	userService, rctx, ok := NewTestUser()
 	if !ok {
 		return
 	}
@@ -77,14 +84,14 @@ func TestGetSetting_User(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := userService.GetSettings(tt.userId)
+			serviceResponse := userService.GetSettings(rctx, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestUpdate_User(t *testing.T) {
-	userService, ok := NewTestUser()
+	userService, rctx, ok := NewTestUser()
 	if !ok {
 		return
 	}
@@ -121,14 +128,14 @@ func TestUpdate_User(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := userService.Update(tt.payload, tt.userId)
+			serviceResponse := userService.Update(rctx, tt.payload, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}
 }
 
 func TestUpdateSetting_User(t *testing.T) {
-	userService, ok := NewTestUser()
+	userService, rctx, ok := NewTestUser()
 	if !ok {
 		return
 	}
@@ -167,7 +174,7 @@ func TestUpdateSetting_User(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			serviceResponse := userService.UpdateSettings(tt.payload, tt.userId)
+			serviceResponse := userService.UpdateSettings(rctx, tt.payload, tt.userId)
 			assert.Equal(t, tt.expectError, serviceResponse.HasError())
 		})
 	}


### PR DESCRIPTION
Fix panic in JWT middleware caused by incorrect type assertion

- Safely extract user_id, session_id, and user_type from jwt.MapClaims
- Convert float64 values to correct types: uint, int8, and commonType.UserType
- Added proper type checks to avoid runtime panics

